### PR TITLE
Improve documentation and export new modules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,16 +60,36 @@ Here is a basic example of how to use one of the functions from the library. Thi
     print("Calculated heat flux at the first 5 time steps:")
     print(Gz[:5])
 
+Another example using the FAO-56 monthly method:
+
+.. code-block:: python
+
+    from soil_heat import soil_heat_flux_monthly
+
+    # Monthly mean temperatures for March and May (°C)
+    t_mar = 14.1
+    t_may = 18.8
+
+    # Calculate April soil heat flux
+    g_apr = soil_heat_flux_monthly(t_mar, t_may)
+    print(f"April soil heat flux: {g_apr:.3f} MJ m-2 day-1")
+
 
 Implemented Models
 ------------------
 
-The library includes implementations from the following key publications:
+The library includes implementations from the following key publications and standards:
 
+*   **Allen, R.G., et al. (1998)**: FAO-56 Crop Evapotranspiration - Guidelines for computing crop water requirements.
+*   **ASCE-EWRI (2005)**: The ASCE Standardized Reference Evapotranspiration Equation.
 *   **Gao, Z., et al. (2017)**: Soil thermal conductivity parameterization.
 *   **Liebethal, C., & Foken, T. (2006)**: Evaluation of six parameterization approaches for the ground heat flux.
 *   **Wang, Z.-H., & Bou-Zeid, E. (2012)**: A novel approach for the estimation of soil ground heat flux.
 *   **Yang, K., & Wang, J. (2008)**: A temperature prediction-correction method for estimating surface soil heat flux.
+
+The library also includes modules for:
+
+*   **Soil and Canopy Heat Storage**: Methods to calculate energy storage in the soil and plant canopy.
 
 Please refer to the documentation for each module for a detailed list of the implemented equations.
 

--- a/docs/autoapi/soil_heat/fao56_soil_heat_flux/index.rst
+++ b/docs/autoapi/soil_heat/fao56_soil_heat_flux/index.rst
@@ -1,0 +1,408 @@
+soil_heat.fao56_soil_heat_flux
+==============================
+
+.. py:module:: soil_heat.fao56_soil_heat_flux
+
+.. autoapi-nested-parse::
+
+   FAO-56 Soil Heat Flux (G) Calculation Functions
+   ================================================
+
+   Implements soil heat flux estimation methods from:
+       Allen, R.G., Pereira, L.S., Raes, D., Smith, M. (1998).
+       "Crop evapotranspiration - Guidelines for computing crop water
+       requirements." FAO Irrigation and Drainage Paper 56. Rome, Italy.
+
+   Also includes the ASCE Standardized Reference ET hourly G estimation:
+       ASCE-EWRI (2005). "The ASCE Standardized Reference Evapotranspiration
+       Equation." ASCE Reston, VA.
+
+   Equations Implemented
+   ---------------------
+   - **Eq. 41**: General soil heat flux from soil heat capacity, temperature
+     change, effective depth, and time interval.
+   - **Eq. 42**: Daily soil heat flux for a grass reference surface (G ≈ 0).
+   - **Eq. 43**: Monthly soil heat flux using the previous and next month's
+     mean air temperatures.
+   - **Eq. 44**: Monthly soil heat flux using the previous and current month's
+     mean air temperatures (when next month is unavailable).
+   - **ASCE Hourly**: Sub-daily soil heat flux as a fraction of net radiation
+     (Rn), with different coefficients for daytime and nighttime.
+
+   Units
+   -----
+   Temperatures in degrees Celsius.
+   Soil heat flux in MJ m⁻² day⁻¹ (or MJ m⁻² hr⁻¹ for hourly).
+   Can be converted to equivalent evaporation (mm day⁻¹) using
+   ``energy_to_evap()``.
+
+   Author: Generated for Paul Inkenbrandt / Utah Geological Survey
+
+
+
+Attributes
+----------
+
+.. autoapisummary::
+
+   soil_heat.fao56_soil_heat_flux.DEFAULT_CS
+   soil_heat.fao56_soil_heat_flux.LATENT_HEAT_INV
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_general
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_daily
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_monthly
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_monthly_prev_only
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_hourly
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_hourly_auto
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_monthly_series
+   soil_heat.fao56_soil_heat_flux.soil_heat_flux_annual_cycle
+   soil_heat.fao56_soil_heat_flux.energy_to_evap
+   soil_heat.fao56_soil_heat_flux.evap_to_energy
+   soil_heat.fao56_soil_heat_flux.mj_m2_day_to_w_m2
+   soil_heat.fao56_soil_heat_flux.w_m2_to_mj_m2_day
+   soil_heat.fao56_soil_heat_flux._run_tests
+
+
+Module Contents
+---------------
+
+.. py:data:: DEFAULT_CS
+   :value: 2.1
+
+
+.. py:data:: LATENT_HEAT_INV
+   :value: 0.408
+
+
+.. py:function:: soil_heat_flux_general(t_current: Union[float, numpy.typing.ArrayLike], t_previous: Union[float, numpy.typing.ArrayLike], delta_t: float, delta_z: float = 1.0, c_s: float = DEFAULT_CS) -> Union[float, numpy.ndarray]
+
+   Soil heat flux from the general calorimetric equation (FAO-56 Eq. 41).
+
+   .. math::
+       G = c_s \, \frac{T_i - T_{i-1}}{\Delta t} \, \Delta z
+
+   :param t_current: Mean air temperature of the current period [°C].
+   :type t_current: float or array_like
+   :param t_previous: Mean air temperature of the previous period [°C].
+   :type t_previous: float or array_like
+   :param delta_t: Length of the time interval in **days**.  For successive months use
+                   ~30.4; for a single month pair use the actual number of days between
+                   the midpoints of the two months.
+   :type delta_t: float
+   :param delta_z: Effective soil depth [m].  Typical values are 0.10–0.20 m for daily
+                   periods and 0.5–2.0 m for monthly periods.  Default is 1.0 m
+                   (standard for successive-month calculations).
+   :type delta_z: float, optional
+   :param c_s: Soil heat capacity [MJ m⁻³ °C⁻¹].  Default ``2.1``.
+   :type c_s: float, optional
+
+   :returns: Soil heat flux *G* [MJ m⁻² day⁻¹].  Positive values indicate heat
+             transfer into the soil (warming); negative values indicate heat
+             release from the soil (cooling).
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   This is the most general form.  Equations 43 and 44 are simplified
+   versions derived from this equation by assuming c_s = 2.1 MJ/(m³·°C),
+   Δz = 1.0 m, and Δt appropriate for monthly intervals (~30 days).
+
+   For Eq. 43:  0.07 ≈ 2.1 × 1.0 / (2 × 30)
+   For Eq. 44:  0.14 ≈ 2.1 × 1.0 / (1 × 30)  (÷ by half the interval)
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — March to April:
+
+   >>> soil_heat_flux_general(16.1, 14.1, delta_t=30.0, delta_z=1.0)
+   0.14
+
+
+.. py:function:: soil_heat_flux_daily() -> float
+
+   Daily soil heat flux for a grass reference surface (FAO-56 Eq. 42).
+
+   For a daily time step, soil heat flux beneath a grass reference surface
+   is small relative to net radiation and may be assumed to be zero.
+
+   :returns: ``0.0`` [MJ m⁻² day⁻¹].
+   :rtype: float
+
+   .. rubric:: Notes
+
+   This assumption holds for a dense, grass-covered surface where the soil
+   surface temperature cycle nearly cancels over 24 hours.  For bare soil
+   or sparse vegetation, daily *G* can be significant and should be
+   estimated by other means (e.g., the general equation or measured data).
+
+
+.. py:function:: soil_heat_flux_monthly(t_month_prev: Union[float, numpy.typing.ArrayLike], t_month_next: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Monthly soil heat flux using adjacent months (FAO-56 Eq. 43).
+
+   When both the previous and next month's mean air temperatures are
+   available, this is the preferred monthly estimate.
+
+   .. math::
+       G_{\text{month},i} = 0.07 \, (T_{i+1} - T_{i-1})
+
+   :param t_month_prev: Mean air temperature of the **previous** month [°C].
+   :type t_month_prev: float or array_like
+   :param t_month_next: Mean air temperature of the **next** month [°C].
+   :type t_month_next: float or array_like
+
+   :returns: Monthly soil heat flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   The coefficient 0.07 derives from Eq. 41 with c_s = 2.1 MJ/(m³·°C),
+   Δz = 1.0 m, and a two-month span (Δt ≈ 2 × 30 = 60 days):
+
+       2.1 × 1.0 / 60 = 0.035  →  rounded/adopted as 0.07 in FAO-56.
+
+   (The FAO text notes that the coefficient accounts for the relationship
+   between air and soil temperature damping; it is empirically calibrated
+   for a grass reference surface.)
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — April soil heat flux (March = 14.1 °C, May = 18.8 °C):
+
+   >>> soil_heat_flux_monthly(14.1, 18.8)
+   0.329
+
+
+.. py:function:: soil_heat_flux_monthly_prev_only(t_month_prev: Union[float, numpy.typing.ArrayLike], t_month_cur: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Monthly soil heat flux — next month unavailable (FAO-56 Eq. 44).
+
+   When the next month's temperature is not yet known (e.g., real-time or
+   forecast applications), use this equation with the current and previous
+   month.
+
+   .. math::
+       G_{\text{month},i} = 0.14 \, (T_i - T_{i-1})
+
+   :param t_month_prev: Mean air temperature of the **previous** month [°C].
+   :type t_month_prev: float or array_like
+   :param t_month_cur: Mean air temperature of the **current** month [°C].
+   :type t_month_cur: float or array_like
+
+   :returns: Monthly soil heat flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   The coefficient 0.14 is exactly twice the Eq. 43 coefficient because
+   the temperature difference spans only one month instead of two:
+
+       2.1 × 1.0 / 30 ≈ 0.07 × 2 = 0.14
+
+   When both adjacent months are available, prefer ``soil_heat_flux_monthly()``
+   (Eq. 43) for greater accuracy.
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — March soil heat flux (Feb = 12.1 °C, Mar = 14.1 °C):
+
+   >>> soil_heat_flux_monthly_prev_only(12.1, 14.1)
+   0.28
+
+
+.. py:function:: soil_heat_flux_hourly(rn: Union[float, numpy.typing.ArrayLike], is_daytime: Union[bool, numpy.typing.ArrayLike], day_coeff: float = 0.1, night_coeff: float = 0.5) -> Union[float, numpy.ndarray]
+
+   Hourly (sub-daily) soil heat flux as a fraction of net radiation.
+
+   Based on the ASCE Standardized Reference Evapotranspiration Equation
+   (ASCE-EWRI, 2005), which recommends estimating *G* for hourly or
+   shorter periods as a proportion of net radiation *Rn*:
+
+   .. math::
+       G_{\text{day}}   &= 0.1 \; R_n   \quad \text{(daytime)}
+
+       G_{\text{night}} &= 0.5 \; R_n   \quad \text{(nighttime)}
+
+   :param rn: Net radiation at the crop surface [MJ m⁻² hr⁻¹].
+   :type rn: float or array_like
+   :param is_daytime: ``True`` for daytime periods, ``False`` for nighttime.
+                      For array inputs, must be broadcastable with *rn*.
+   :type is_daytime: bool or array_like of bool
+   :param day_coeff: Fraction of Rn used for daytime G.  Default ``0.1``.
+   :type day_coeff: float, optional
+   :param night_coeff: Fraction of Rn used for nighttime G.  Default ``0.5``.
+   :type night_coeff: float, optional
+
+   :returns: Soil heat flux [MJ m⁻² hr⁻¹] (same units as *rn*).
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   Daytime is typically defined as the period when *Rn* > 0.  Some
+   implementations use the solar angle or the time relative to sunrise
+   and sunset instead.
+
+   The default coefficients (0.1 / 0.5) are calibrated for a grass
+   reference surface.  For other surfaces the ratio G/Rn can vary
+   considerably (see Allen et al., 1998, Table 7-2).
+
+   .. rubric:: Examples
+
+   Daytime hour with Rn = 2.5 MJ m⁻² hr⁻¹:
+
+   >>> soil_heat_flux_hourly(2.5, is_daytime=True)
+   0.25
+
+   Nighttime hour with Rn = -0.4 MJ m⁻² hr⁻¹:
+
+   >>> soil_heat_flux_hourly(-0.4, is_daytime=False)
+   -0.2
+
+
+.. py:function:: soil_heat_flux_hourly_auto(rn: Union[float, numpy.typing.ArrayLike], day_coeff: float = 0.1, night_coeff: float = 0.5) -> Union[float, numpy.ndarray]
+
+   Hourly soil heat flux, auto-detecting day/night from Rn sign.
+
+   Convenience wrapper around :func:`soil_heat_flux_hourly` that uses
+   ``Rn > 0`` as the daytime indicator, which is the most common approach
+   in practice.
+
+   :param rn: Net radiation at the crop surface [MJ m⁻² hr⁻¹].
+   :type rn: float or array_like
+   :param day_coeff: Fraction of Rn used for daytime G.  Default ``0.1``.
+   :type day_coeff: float, optional
+   :param night_coeff: Fraction of Rn used for nighttime G.  Default ``0.5``.
+   :type night_coeff: float, optional
+
+   :returns: Soil heat flux [MJ m⁻² hr⁻¹].
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Examples
+
+   >>> soil_heat_flux_hourly_auto(2.5)
+   0.25
+   >>> soil_heat_flux_hourly_auto(-0.4)
+   -0.2
+
+
+.. py:function:: soil_heat_flux_monthly_series(t_monthly: numpy.typing.ArrayLike, method: str = 'centered') -> numpy.ndarray
+
+   Compute soil heat flux for each month in a temperature time series.
+
+   This is a convenience function that applies the appropriate FAO-56
+   monthly equation to each element of a monthly mean-temperature array.
+
+   :param t_monthly: 1-D array of consecutive monthly mean air temperatures [°C].
+                     Length *N* ≥ 2.
+   :type t_monthly: array_like
+   :param method:
+                  * ``"centered"`` (default) — Uses Eq. 43 where both neighbors
+                    exist; falls back to Eq. 44 at the boundaries (first and last
+                    month).
+                  * ``"backward"`` — Uses Eq. 44 for every month (each month
+                    compared only to the previous month).  The first element is
+                    set to ``NaN`` because there is no previous month.
+   :type method: {"centered", "backward"}, optional
+
+   :returns: Array of monthly soil heat flux values [MJ m⁻² day⁻¹], same
+             length as *t_monthly*.
+   :rtype: numpy.ndarray
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — March, April, May temps:
+
+   >>> temps = [14.1, 16.1, 18.8]
+   >>> soil_heat_flux_monthly_series(temps, method="centered")
+   array([0.28 , 0.329, 0.378])
+
+   Using backward-only differences:
+
+   >>> soil_heat_flux_monthly_series(temps, method="backward")
+   array([  nan, 0.28 , 0.378])
+
+
+.. py:function:: soil_heat_flux_annual_cycle(t_monthly_12: numpy.typing.ArrayLike) -> numpy.ndarray
+
+   Monthly G for a complete 12-month annual cycle using Eq. 43.
+
+   Wraps around so that January uses December and February as neighbors,
+   and December uses November and January.
+
+   :param t_monthly_12: Exactly 12 monthly mean air temperatures [°C], January through
+                        December.
+   :type t_monthly_12: array_like
+
+   :returns: Shape ``(12,)`` array of monthly soil heat flux [MJ m⁻² day⁻¹].
+   :rtype: numpy.ndarray
+
+   .. rubric:: Examples
+
+   >>> temps = [5.2, 6.1, 9.3, 13.0, 17.5, 22.1,
+   ...          25.4, 24.8, 20.6, 14.9, 9.2, 5.8]
+   >>> g = soil_heat_flux_annual_cycle(temps)
+   >>> g[0]   # January: 0.07 * (Feb - Dec)
+   0.021...
+
+
+.. py:function:: energy_to_evap(energy: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert energy flux to equivalent evaporation depth (FAO-56 Eq. 20).
+
+   .. math::
+       E_{\text{equiv}} = 0.408 \times E
+
+   :param energy: Energy flux [MJ m⁻² day⁻¹] (or per hour, etc.).
+   :type energy: float or array_like
+
+   :returns: Equivalent evaporation [mm day⁻¹] (or per hour, etc.).
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: evap_to_energy(evap: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert equivalent evaporation depth back to energy flux.
+
+   Inverse of :func:`energy_to_evap`.
+
+   :param evap: Equivalent evaporation [mm day⁻¹].
+   :type evap: float or array_like
+
+   :returns: Energy flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: mj_m2_day_to_w_m2(flux: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert flux from MJ m⁻² day⁻¹ to W m⁻².
+
+   .. math::
+       W\,m^{-2} = \frac{MJ\,m^{-2}\,day^{-1}}{0.0864}
+
+   :param flux: Energy flux [MJ m⁻² day⁻¹].
+   :type flux: float or array_like
+
+   :returns: Energy flux [W m⁻²].
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: w_m2_to_mj_m2_day(flux: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert flux from W m⁻² to MJ m⁻² day⁻¹.
+
+   :param flux: Energy flux [W m⁻²].
+   :type flux: float or array_like
+
+   :returns: Energy flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: _run_tests() -> None
+
+   Reproduce FAO-56 Example 13 and other verification cases.

--- a/docs/autoapi/soil_heat/gao_et_al/index.rst
+++ b/docs/autoapi/soil_heat/gao_et_al/index.rst
@@ -33,105 +33,1314 @@ Module Contents
 
 .. py:function:: lambda_s(theta: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Thermal conductivity (λ_s) as a function of volumetric water content θ.
+   Compute the **soil thermal conductivity** :math:`\lambda_s`
+   as a function of volumetric water content (θ).
 
-   Implements Eq. (12) from Gao et al. (2017) fileciteturn1file3.
+   The relationship is taken from Gao et al. (2017, Eq. 12):
+
+   .. math::
+
+       \lambda_s(\theta) = 0.20 + \exp\bigl[\,1.46\,(\theta - 0.34)\bigr]
+
+   :param theta: Volumetric water content (m³ m⁻³).
+                 Accepts a scalar value or any array-like object that can be
+                 converted to a :class:`numpy.ndarray`. Values should lie in the
+                 closed interval ``[0, 1]``.
+   :type theta: float or array_like
+
+   :returns: Soil thermal conductivity λ\_s in W m⁻¹ K⁻¹.  The returned type
+             matches the input: a scalar is returned for a scalar *θ*, and a
+             NumPy array for array-like *θ*.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *θ* is outside the physically meaningful
+       range ``[0, 1]``.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – The function is fully vectorized; it operates
+     element-wise on NumPy arrays and broadcasts according to NumPy
+     broadcasting rules.
+   * **Empirical limits** – Gao et al. recommend the equation for
+     mineral soils where 0 ≤ θ ≤ 0.5. Extrapolation beyond this range
+     may introduce error.
+   * **Units** – The output uses SI units (W m⁻¹ K⁻¹).
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   **Soil thermal conductivity parameterization: A closed-form
+   equation and its evaluation.** *Journal of Geophysical Research:
+   Atmospheres*, 122(6), 3466–3478.
+   DOI: 10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> lambda_s(0.25)
+   0.463...
+   >>> import numpy as np
+   >>> theta = np.linspace(0, 0.5, 5)
+   >>> lambda_s(theta)
+   array([0.20      , 0.31243063, 0.41172297, 0.51210322, 0.61861198])
 
 
 .. py:function:: k_s(theta: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Thermal diffusivity (k_s) as a function of volumetric water content θ.
+   Calculate the **soil thermal diffusivity** :math:`k_s`
+   as a function of volumetric water content (θ).
 
-   Implements Eq. (13) from Gao et al. (2017) fileciteturn1file6.
+   The empirical relationship follows Gao et al. (2017, Eq. 13):
+
+   .. math::
+
+       k_s(\theta) = \bigl[0.69 + \exp\bigl(3.06\,(\theta - 0.26)\bigr)\bigr] \times 10^{-7}
+
+   :param theta: Volumetric water content (m³ m⁻³).
+                 Accepts a scalar or any array-like sequence convertible to a
+                 :class:`numpy.ndarray`. Values **must** lie in the closed
+                 interval ``[0, 1]``.
+   :type theta: float or array_like
+
+   :returns: Soil thermal diffusivity *k\_s* in m² s⁻¹.
+             A scalar is returned if *θ* is a scalar; otherwise a NumPy array
+             of matching shape is returned.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *θ* is outside the physically meaningful
+       range ``[0, 1]``.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – The calculation is fully vectorized and
+     broadcasts according to NumPy rules.
+   * **Applicability** – Gao et al. derived this expression for mineral
+     soils under typical field conditions. Extrapolating beyond
+     0 ≤ θ ≤ 0.5 may reduce accuracy.
+   * **Units** – Output is in SI units (m² s⁻¹).
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   *Soil thermal conductivity parameterization: A closed-form equation
+   and its evaluation.* Journal of Geophysical Research: Atmospheres,
+   **122**(6), 3466–3478. https://doi.org/10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> k_s(0.25)
+   1.321...e-07
+   >>> thetas = np.linspace(0, 0.5, 6)
+   >>> k_s(thetas)
+   array([1.14...e-07, 1.21...e-07, 1.30...e-07, 1.41...e-07,
+          1.54...e-07, 1.69...e-07])
 
 
-.. py:function:: volumetric_heat_capacity(lambda_s_val, k_s_val)
+.. py:function:: volumetric_heat_capacity(lambda_s_val: numpy.ndarray | float, k_s_val: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Volumetric heat capacity C_v = λ_s / k_s (units J m⁻³ K⁻¹).
+   Compute the **volumetric heat capacity** :math:`C_v` of soil:
+
+   .. math::
+
+       C_v \;=\; \frac{\lambda_s}{k_s}
+
+   where
+   :math:`\lambda_s` is the **thermal conductivity** (W m⁻¹ K⁻¹) and
+   :math:`k_s` is the **thermal diffusivity** (m² s⁻¹).
+
+   The resulting heat capacity has units of J m⁻³ K⁻¹.
+
+   :param lambda_s_val: Soil thermal conductivity (W m⁻¹ K⁻¹). May be a scalar or any
+                        array-like structure broadcastable with *k_s_val*.
+   :type lambda_s_val: float or array_like
+   :param k_s_val: Soil thermal diffusivity (m² s⁻¹). Must be positive. Accepts a
+                   scalar or array-like input.
+   :type k_s_val: float or array_like
+
+   :returns: Volumetric heat capacity *C_v* (J m⁻³ K⁻¹).  The return type
+             matches the input: a scalar for scalar inputs, or a NumPy array
+             for array-like inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element in *k_s_val* is zero or negative, which would
+       lead to division by zero or non-physical results.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – The function is fully vectorized; both inputs
+     are converted to :class:`numpy.ndarray` and follow NumPy
+     broadcasting rules.
+   * **Physical meaning** – Volumetric heat capacity represents the
+     energy required to raise the temperature of a unit volume of soil
+     by one kelvin. High values correspond to moist or water-logged
+     soils; dry mineral soils have lower *C_v*.
+
+   .. rubric:: Examples
+
+   >>> #Scalar inputs
+   >>> volumetric_heat_capacity(0.8, 1.2e-6)
+   666666.666...
+
+   >>> #Vectorized inputs
+   >>> lambda_vals = np.array([0.5, 0.6, 0.7])
+   >>> diffusivities = np.array([1.1e-6, 1.2e-6, 1.3e-6])
+   >>> volumetric_heat_capacity(lambda_vals, diffusivities)
+   array([454545.4545..., 500000.    ..., 538461.5384...])
 
 
-.. py:function:: nme(calc: numpy.ndarray, meas: numpy.ndarray) -> float
+.. py:function:: nme(calc: numpy.ndarray | float, meas: numpy.ndarray | float) -> float
 
-   Normalized mean error (%). Implements Eq. (14) fileciteturn1file8.
+   Calculate the **normalized mean error (NME)** between calculated
+   and measured values, expressed as a percentage.
+
+   The formulation follows Gao et al. (2017, Eq. 14):
+
+   .. math::
+
+       \text{NME} \;=\; 100\,\frac{\sum\limits_{i}\left|\hat{y}_i - y_i\right|}
+                                     {\sum\limits_{i}\left|y_i\right|}
+
+   where :math:`\hat{y}_i` are the *calculated* (model) values and
+   :math:`y_i` are the *measured* (reference) values.
+
+   :param calc: Modelled / calculated values :math:`\hat{y}`.
+                Accepts any array-like object (including scalars) convertible to
+                a :class:`numpy.ndarray`.
+   :type calc: float or array_like
+   :param meas: Measured / observed reference values :math:`y`. Must be
+                broadcast-compatible with *calc*.
+   :type meas: float or array_like
+
+   :returns: Normalized mean error (percent).
+             A value of **0 %** indicates perfect agreement; larger values
+             indicate greater error.
+   :rtype: float
+
+   :raises ValueError: * If *calc* and *meas* cannot be broadcast to a common shape.
+       * If the denominator ``Σ|meas|`` equals zero (e.g., all measured
+         values are zero), which would make NME undefined.
+
+   .. rubric:: Notes
+
+   * **Range** – NME is non-negative and unbounded above.
+   * **Interpretation** – Because both numerator and denominator use
+     absolute values, NME is insensitive to the direction of the error
+     (over- vs under-prediction) and therefore complements signed error
+     metrics such as mean bias.
+   * **Vectorization** – The implementation is fully vectorized and
+     adheres to NumPy broadcasting rules.
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   *Soil thermal conductivity parameterization: A closed-form equation
+   and its evaluation.* **Journal of Geophysical Research:
+   Atmospheres**, 122(6), 3466–3478.
+   https://doi.org/10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> # Single values
+   >>> nme(4.5, 5.0)
+   10.0
+
+   >>> # Vectors
+   >>> calc = np.array([1.0, 2.1, 3.2])
+   >>> meas = np.array([1.2, 2.0, 3.0])
+   >>> nme(calc, meas)
+   4.7619...
+
+   >>> # Broadcasting (scalar vs array)
+   >>> nme(2.0, np.array([1.5, 2.5, 2.0]))
+   16.6666...
 
 
-.. py:function:: rmse(calc: numpy.ndarray, meas: numpy.ndarray) -> float
+.. py:function:: rmse(calc: numpy.ndarray | float, meas: numpy.ndarray | float) -> float
 
-   Root‑mean‑square error. Implements Eq. (15) fileciteturn1file8.
+   Compute the **root-mean-square error (RMSE)** between calculated
+   (model) and measured (reference) values.
+
+   Following Gao et al. (2017, Eq. 15):
+
+   .. math::
+
+       \text{RMSE} \;=\;
+       \sqrt{\frac{1}{N}\sum_{i=1}^{N}\bigl(\hat{y}_i - y_i\bigr)^2}
+
+   where :math:`\hat{y}_i` are *calculated* values and
+   :math:`y_i` are *measured* values.
+
+   :param calc: Calculated / modelled values :math:`\hat{y}`.  Accepts a scalar
+                or any array-like object convertible to a
+                :class:`numpy.ndarray`.
+   :type calc: float or array_like
+   :param meas: Measured / observed values :math:`y`. Must be broadcast-
+                compatible with *calc*.
+   :type meas: float or array_like
+
+   :returns: Root-mean-square error (same units as the inputs).
+   :rtype: float
+
+   :raises ValueError: * If *calc* and *meas* cannot be broadcast to a common shape.
+       * If the input arrays are empty (``N = 0``).
+
+   .. rubric:: Notes
+
+   * **Interpretation** – RMSE represents the sample-standard-deviation
+     of the differences between two datasets; lower values indicate
+     better agreement.
+   * **Vectorization** – The function is fully vectorized and respects
+     NumPy broadcasting rules.
+   * **Units** – RMSE preserves the units of the input variables.
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   *Soil thermal conductivity parameterization: A closed-form equation
+   and its evaluation.* Journal of Geophysical Research:
+   Atmospheres, **122**(6), 3466–3478.
+   https://doi.org/10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> # Scalar inputs
+   >>> rmse(4.5, 5.0)
+   0.5
+
+   >>> # Vector inputs
+   >>> calc = np.array([2.1, 3.0, 4.2])
+   >>> meas = np.array([2.0, 3.5, 4.0])
+   >>> rmse(calc, meas)
+   0.2645...
+
+   >>> # Broadcasting
+   >>> rmse(3.0, np.array([2.5, 3.5, 3.0]))
+   0.4082...
 
 
-.. py:function:: calorimetric_gz(g_zr, cv_layers, dT_dt_layers, dz_layers)
+.. py:function:: calorimetric_gz(g_zr: numpy.ndarray | float, cv_layers: numpy.ndarray | float, dT_dt_layers: numpy.ndarray | float, dz_layers: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Calorimetric method for G_z at depth z (usually 5 cm).
+   Estimate the **soil heat flux** at a target depth *z*
+   (typically 5 cm) using the *calorimetric method*.
 
-   :param g_zr: Measured heat flux at reference depth *z_r* (W m⁻²).
+   The method corrects an in-situ heat-flux plate reading made at a
+   reference depth *z_r* by adding the change in heat storage of the
+   soil column located between *z* and *z_r*.  Mathematically
+   (Liebethal & Foken 2007, Eq. 1):
+
+   .. math::
+
+       G(z,t) \;=\; G(z_r,t) \;+\;
+       \sum_{l=1}^{N}
+       C_{v,l}\,\frac{\partial \bar{T}_l}{\partial t}\,\Delta z_l
+
+   where
+
+   * :math:`G(z,t)`     … heat flux at depth *z* (W m⁻²)
+   * :math:`G(z_r,t)`   … measured plate flux at reference depth *z_r*
+   * :math:`C_{v,l}`    … volumetric heat capacity of layer *l*
+     (J m⁻³ K⁻¹)
+   * :math:`\partial \bar{T}_l / \partial t` … time derivative of the
+     layer-averaged temperature (K s⁻¹)
+   * :math:`\Delta z_l` … thickness of layer *l* (m)
+
+   :param g_zr: Heat-flux plate measurement at depth *z_r* (W m⁻²).  Can be a
+                scalar or time series.
    :type g_zr: float or array_like
-   :param cv_layers: Volumetric heat capacity for each sub‑layer *C_v,l* (J m⁻³ K⁻¹).
-   :type cv_layers: sequence
-   :param dT_dt_layers: Time derivative of average temperature for each layer ∂T/∂t (K s⁻¹).
-   :type dT_dt_layers: sequence
-   :param dz_layers: Thickness of each sub‑layer δz_l (m).
-   :type dz_layers: sequence
+   :param cv_layers: Volumetric heat capacity :math:`C_{v,l}` for each of *N* soil
+                     sub-layers (J m⁻³ K⁻¹).  Shape ``(N, …)`` where the trailing
+                     dimensions (``…``) must be broadcast-compatible with *g_zr*.
+   :type cv_layers: array_like
+   :param dT_dt_layers: Time derivative of layer-mean temperature
+                        :math:`\partial \bar{T}_l / \partial t`
+                        (K s⁻¹); same shape as *cv_layers*.
+   :type dT_dt_layers: array_like
+   :param dz_layers: Thickness of each layer :math:`\Delta z_l` (m); shape ``(N,)``
+                     or broadcast-compatible with the first axis of *cv_layers*.
+   :type dz_layers: array_like
+
+   :returns: Calorimetrically corrected soil heat flux *G(z)* (W m⁻²).  Scalar
+             if all inputs are scalar; otherwise a NumPy array matching the
+             broadcast shape of *g_zr*.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If the inputs cannot be broadcast to a common shape, or if the
+       number of layers inferred from *cv_layers*, *dT_dt_layers*, and
+       *dz_layers* are inconsistent.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – All operations are fully vectorized.  Inputs
+     are converted to :class:`numpy.ndarray` and follow NumPy
+     broadcasting rules.
+   * **Layer axis** – The first dimension of *cv_layers* and
+     *dT_dt_layers* (axis 0) is interpreted as the layer index *l*.
+     Layer thicknesses *dz_layers* are broadcast across any additional
+     dimensions.
+   * **Units** – Ensure consistent SI units: W m⁻², J m⁻³ K⁻¹,
+     K s⁻¹, and m.
+
+   .. rubric:: References
+
+   Liebethal, C., & Foken, T. (2007). *Evaluation of six parameterization
+   approaches for the ground heat flux.* Agricultural and Forest
+   Meteorology, **143**(1–2), 65-80.
+   https://doi.org/10.1016/j.agrformet.2006.11.001
+
+   .. rubric:: Examples
+
+   >>> # Three-layer example, single time step
+   >>> g_plate = -15.2                      # W m-2 at z_r = −0.05 m
+   >>> Cv     = np.array([2.5e6, 2.3e6, 2.1e6])   # J m-3 K-1
+   >>> dTdt   = np.array([1.2e-4, 0.9e-4, 0.6e-4])  # K s-1
+   >>> dz     = np.array([0.02, 0.02, 0.01])       # m
+   >>> calorimetric_gz(g_plate, Cv, dTdt, dz)
+   -4.06...
+
+   >>> # Vectorized daily time series with two layers
+   >>> g_plate = np.random.normal(-10, 2, 1440)        # per minute
+   >>> Cv       = np.array([[2.4e6], [2.2e6]])         # (2,1)
+   >>> dTdt     = np.random.normal(5e-5, 2e-5, (2,1440))
+   >>> dz       = np.array([0.03, 0.02])
+   >>> Gz = calorimetric_gz(g_plate, Cv, dTdt, dz)     # shape (1440,)
 
 
-.. py:function:: force_restore_gz(cv, dTg_dt, Tg, Tg_bar, delta_z=0.05, omega=OMEGA_DAY)
+.. py:function:: force_restore_gz(cv: numpy.ndarray | float, dTg_dt: numpy.ndarray | float, Tg: numpy.ndarray | float, Tg_bar: numpy.ndarray | float, delta_z: float = 0.05, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   Force‑restore estimate of G_z at z = δz (default 5 cm).
+   Estimate **soil heat flux** :math:`G(z)` at a shallow depth
+   (:math:`z = \delta z`, default 5 cm) with the **force–restore
+   method**.
 
-   Implements Eq. (2) fileciteturn1file2.
+   The formulation (Liebethal & Foken 2007, Eq. 2) corrects the
+   calorimetric storage term with a *restore* component that accounts
+   for the difference between the instantaneous ground temperature
+   *T_g* and its running mean *\bar{T}_g*:
+
+   .. math::
+
+       G(z,t) \;=\; C_v \, \delta z \, \frac{\partial T_g}{\partial t}
+       \;+
+       \sqrt{\omega \, C_v \, \lambda_s(C_v)}
+       \left[
+           \frac{1}{\omega}\,\frac{\partial T_g}{\partial t}
+           + \bigl(T_g - \bar{T}_g\bigr)
+       \right]
+
+   where
+
+   * :math:`C_v`   … volumetric heat capacity (J m⁻³ K⁻¹)
+   * :math:`\partial T_g / \partial t` … ground-temperature tendency
+     (K s⁻¹)
+   * :math:`\lambda_s(C_v)` … soil thermal conductivity derived from
+     *C_v* via :func:`lambda_s_from_cv` (W m⁻¹ K⁻¹)
+   * :math:`\omega` … angular frequency of the diurnal cycle
+     (rad s⁻¹)
+   * :math:`T_g` / :math:`\bar{T}_g` … instantaneous and running-mean
+     ground temperature (K)
+   * :math:`\delta z` … sensor depth below the surface (m)
+
+   :param cv: Volumetric heat capacity :math:`C_v` (J m⁻³ K⁻¹).  Must be
+              positive.  Accepts scalars or NumPy-broadcastable arrays.
+   :type cv: float or array_like
+   :param dTg_dt: Time derivative :math:`\partial T_g/\partial t` (K s⁻¹).
+   :type dTg_dt: float or array_like
+   :param Tg: Instantaneous ground (surface) temperature :math:`T_g` (K or °C)
+              at depth *δz*.
+   :type Tg: float or array_like
+   :param Tg_bar: Running mean ground temperature :math:`\bar{T}_g` over the
+                  diurnal cycle (same units as *Tg*).
+   :type Tg_bar: float or array_like
+   :param delta_z: Depth :math:`\delta z` in metres; default is **0.05 m**
+                   (5 cm).
+   :type delta_z: float, optional
+   :param omega: Angular frequency :math:`\omega` in rad s⁻¹.  Defaults to
+                 :pydata:`OMEGA_DAY` (2π / 86 400 s).
+   :type omega: float, optional
+
+   :returns: Soil heat flux *G(z)* at depth *δz* (W m⁻²).  The output shape
+             follows NumPy broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any input arrays cannot be broadcast to a common shape, or if
+       *cv* contains non-positive values.
+
+   .. rubric:: Notes
+
+   * **λ_s(C_v) mapping** – The function relies on a helper
+     :func:`lambda_s_from_cv` that converts volumetric heat capacity
+     to thermal conductivity.  Ensure that this helper is present in
+     the import path.
+   * **Units** – Keep units internally consistent (SI).
+   * **Vectorization** – All operations are vectorized; the
+     mathematical expression is evaluated element-wise for array
+     inputs.
+   * **Interpretation** – The first term represents *storage*
+     (calorimetric), while the second tempers short-term fluctuations,
+     “restoring” *T_g* toward its mean.
+
+   .. rubric:: References
+
+   Liebethal, C., & Foken, T. (2007). *Evaluation of six
+   parameterization approaches for the ground heat flux.*
+   **Agricultural and Forest Meteorology**, 143(1–2), 65-80.
+   https://doi.org/10.1016/j.agrformet.2006.11.001
+
+   .. rubric:: Examples
+
+   >>> Cv      = 2.4e6                 # J m-3 K-1
+   >>> dTgdt   = 1.0e-4                # K s-1
+   >>> Tg      = 293.5                 # K
+   >>> Tg_bar  = 291.7                 # K (running mean)
+   >>> force_restore_gz(Cv, dTgdt, Tg, Tg_bar)
+   19.3...   # W m-2
+
+   >>> #Vectorized daily record
+   >>> cv_arr = np.full(1440, 2.2e6)
+   >>> dT_arr = np.gradient(np.sin(np.linspace(0, 2*np.pi, 1440))) / 60
+   >>> Gz_ts  = force_restore_gz(cv_arr, dT_arr, 298+2*np.sin(...),
+   ...                           298*np.ones_like(dT_arr))
 
 
-.. py:function:: gao2010_gz(AT, lambda_s_val, k_s_val, t, omega=OMEGA_DAY)
+.. py:function:: gao2010_gz(AT: numpy.ndarray | float, lambda_s_val: numpy.ndarray | float, k_s_val: numpy.ndarray | float, t: numpy.ndarray | float, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   Sinusoidal solution for G_z at depth d (Eq. 3).
+   Estimate **soil heat flux** :math:`G(z,t)` at depth *z* based on a
+   *sinusoidal* ground-temperature forcing (Gao et al. 2010, Eq. 3).
+
+   The analytical solution assumes that the surface (or ground-contact)
+   temperature varies sinusoidally with amplitude *A_T* and angular
+   frequency *ω*.  Under these conditions the heat flux at any depth
+   *z* can be written
+
+   .. math::
+
+       G(z,t) \;=\;
+       \sqrt{2}\,
+       \frac{\lambda_s A_T}{d}\,
+       \sin\bigl(\omega t + \tfrac{\pi}{4}\bigr),
+
+   where the **thermal damping depth**
+
+   .. math::
+
+       d \;=\; \sqrt{\frac{2 k_s}{\omega}}
+
+   is determined by the soil thermal diffusivity *k_s* and the forcing
+   frequency *ω*.
+
+   :param AT: Amplitude of the sinusoidal ground-surface temperature (K).
+   :type AT: float or array_like
+   :param lambda_s_val: Soil thermal conductivity :math:`\lambda_s` (W m⁻¹ K⁻¹).
+   :type lambda_s_val: float or array_like
+   :param k_s_val: Soil thermal diffusivity :math:`k_s` (m² s⁻¹).
+   :type k_s_val: float or array_like
+   :param t: Time variable (s).  Can be absolute time since epoch or simply
+             seconds since the start of the cycle—as long as *ω t* is
+             dimensionless.
+   :type t: float or array_like
+   :param omega: Angular frequency *ω* (rad s⁻¹).  Defaults to *OMEGA_DAY*
+                 (≈ 7.272 × 10⁻⁵ s⁻¹, i.e. 2π / 86 400 s).
+   :type omega: float, optional
+
+   :returns: Heat flux *G(z,t)* (W m⁻²).  The output follows NumPy’s
+             broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: * If *lambda_s_val*, *k_s_val*, and *t* cannot be broadcast to a
+         common shape.
+       * If any element of *k_s_val* or *omega* is non-positive.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – All inputs are internally converted to
+     :class:`numpy.ndarray`; the formula is evaluated element-wise and
+     fully supports broadcasting.
+   * **Units** – Ensure consistent SI units: W m⁻¹ K⁻¹ (λ_s),
+     m² s⁻¹ (k_s), s (t), and rad s⁻¹ (ω).
+   * **Scope** – The solution presumes purely sinusoidal boundary
+     forcing and homogeneous soil properties; real-world deviations
+     (e.g., non-sine forcing, stratified soils, moisture variation)
+     will introduce error.
+
+   .. rubric:: References
+
+   Gao, Z., Horton, R., Luo, L., & Kucharik, C. J. (2010).
+   *A simple method to measure soil temperature dynamics: Theory and
+   application.* **Soil Science Society of America Journal**, 74(2),
+   580-588. https://doi.org/10.2136/sssaj2009.0169
+
+   .. rubric:: Examples
+
+   >>> # Daily cycle at 5 cm depth
+   >>> AT      = 8.0                           # K
+   >>> lambda_ = 1.2                           # W m-1 K-1
+   >>> kappa   = 1.0e-6                        # m2 s-1
+   >>> t_day   = np.linspace(0, 86400, 97)     # 15-min steps
+   >>> Gz      = gao2010_gz(AT, lambda_, kappa, t_day)
+   >>> Gz.shape
+   (97,)
 
 
-.. py:function:: heusinkveld_gz(A_n, Phi_n, n_max, k_s_val, lambda_s_val, w)
+.. py:function:: heusinkveld_gz(A_n: numpy.ndarray | float, Phi_n: numpy.ndarray | float, n_max: int, k_s_val: numpy.ndarray | float, lambda_s_val: numpy.ndarray | float, w: float) -> numpy.ndarray | float
 
-   H04 harmonic solution (Eq. 4).
+   Compute *soil heat flux* :math:`G(z,t)` from the **H04 harmonic
+   series solution** proposed by Heusinkveld et al. (2004, Eq. 4).
+
+   The approach represents the surface (ground) temperature as a Fourier
+   series with harmonics up to order *n_max*.  For each harmonic
+   :math:`n` the heat-flux contribution at depth *z* can be written
+
+   .. math::
+
+       G_n(z,t) \;=\;
+       \frac{\lambda_s}{10\,\pi}\,
+       A_n\;
+       \sqrt{\frac{1}{k_s\,n\,\omega\,k_s}}\;
+       \sin\bigl(n\,\omega\,t + \Phi_n + \tfrac{\pi}{4}\bigr),
+
+   and the full signal is obtained by summing over *n = 1…n_max*.
+
+   **Note** The implementation below follows the algebraic form that
+   appeared in H04; consult the original paper for derivation details
+   and recommended parameter ranges.
+
+   :param A_n: Amplitudes :math:`A_n` of the *n*-th harmonic of surface-temperature
+               forcing (K).  Provide either
+               * a single scalar applied to every harmonic, or
+               * an array of length ≥ *n_max* giving amplitude for each harmonic.
+   :type A_n: float or array_like
+   :param Phi_n: Phase shifts :math:`\Phi_n` (rad) corresponding to each harmonic
+                 order.  Same broadcasting rules as *A_n*.
+   :type Phi_n: float or array_like
+   :param n_max: Highest harmonic order to include in the summation.
+   :type n_max: int
+   :param k_s_val: Soil thermal diffusivity :math:`k_s` (m² s⁻¹).
+   :type k_s_val: float or array_like
+   :param lambda_s_val: Soil thermal conductivity :math:`\lambda_s` (W m⁻¹ K⁻¹).
+   :type lambda_s_val: float or array_like
+   :param w: Fundamental angular frequency :math:`\omega` (rad s⁻¹), e.g.
+             :math:`2\pi/86400` for a 24-h cycle.
+   :type w: float
+
+   :returns: Soil heat flux *G(z,t)* (W m⁻²).  The return shape is the
+             broadcast shape of the input arrays (excluding the harmonic axis).
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If *n_max* is less than 1, or if *k_s_val* or *w* are non-positive,
+       or if the amplitudes/phases cannot be broadcast to length
+       *n_max*.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – Internally, the harmonic index axis has length
+     *n_max* (``n = np.arange(1, n_max+1)``).  All other dimensions come
+     from broadcasting *A_n*, *Phi_n*, *k_s_val*, *lambda_s_val*, and
+     *t* (if vectorized in the caller).
+   * **Units** – Consistency with SI units is assumed.
+   * **Interpretation** – The prefactor ``λ_s / (10 π)`` appears in
+     H04’s original derivation.  If you adopt a different convention
+     (e.g., depth-explicit damping), modify accordingly.
+
+   .. rubric:: References
+
+   Heusinkveld, B. G., Jacobs, A. F. G., Holtslag, A. A. M., & *et al.*
+   (2004). *Surface energy balance closure in an arid region: The role
+   of soil heat flux.* Agricultural and Forest Meteorology, **122**(1),
+   21-37. https://doi.org/10.1016/j.agrformet.2003.09.005
+
+   .. rubric:: Examples
+
+   >>> # Daily cycle with three harmonics
+   >>> A = np.array([10, 4, 1.5])          # K
+   >>> Phi = np.array([0, -np.pi/6, np.pi/8])
+   >>> Gz = heusinkveld_gz(A, Phi, n_max=3,
+   ...                     k_s_val=1e-6,
+   ...                     lambda_s_val=1.0,
+   ...                     w=2*np.pi/86400)
+   >>> Gz.shape
+   ()
 
 
-.. py:function:: hsieh2009_gz(tz_series, time_series, cv_series, ks_series)
+.. py:function:: hsieh2009_gz(tz_series: numpy.ndarray | list | tuple, time_series: numpy.ndarray | list | tuple, cv_series: numpy.ndarray | list | tuple, ks_series: numpy.ndarray | list | tuple) -> float
 
-   Half‑order integral solution (Eq. 5).
+   Compute **soil heat flux** at the end of a temperature record
+   using the *half-order integral* (Hsieh et al., 2009, Eq. 5).
 
-   tz_series, cv_series, ks_series must be monotonically increasing in *time_series*.
+   The method exploits the analytical solution of the one-dimensional
+   heat-conduction equation for a semi-infinite medium, leading to a
+   convolution integral of order ½ that relates the time series of
+   near-surface soil temperature to the downward heat flux:
+
+   .. math::
+
+       G(t_N) \;=\;
+       2\sqrt{\frac{k_s(t_N)\,C_v(t_N)}{\pi}}\;
+       \int_{t_0}^{t_N}
+           \frac{\partial T(z,t')}{\partial t'}
+           \left(t_N - t'\right)^{-1/2}\,dt'
+
+   In discrete form with linear interpolation between measurements
+   :math:`t_i \;(i = 0,\dots,N)`,
+
+   .. math::
+
+       \int_{t_0}^{t_N}\!
+           \frac{dT}{dt'}\,(t_N-t')^{-1/2}dt'
+       \approx
+       \sum_{i=0}^{N-1}
+         \frac{\Delta T_i}{\Delta t_i}\!
+         \left[(t_N-t_i)^{1/2} - (t_N-t_{i+1})^{1/2}\right],
+
+   where :math:`\Delta T_i = T_{i+1}-T_i` and
+   :math:`\Delta t_i = t_{i+1}-t_i`.
+
+   The final scalar result corresponds to the flux at
+   :math:`t_N\;(=\text{time_series}[-1])`.
+
+   :param tz_series: Near-surface (or shallow-depth) soil temperature observations
+                     *T(z,t)* (K).  Length **N ≥ 2**.
+   :type tz_series: array_like
+   :param time_series: Strictly monotonically increasing time stamps (s) matching
+                       `tz_series`.  Same length **N**.
+   :type time_series: array_like
+   :param cv_series: Volumetric heat capacity *C_v* (J m⁻³ K⁻¹) at each
+                     time stamp.  Same length **N**.
+   :type cv_series: array_like
+   :param ks_series: Thermal diffusivity *k_s* (m² s⁻¹) at each time stamp.
+                     Same length **N**.
+   :type ks_series: array_like
+
+   :returns: Soil heat flux *G(t_N)* at the final time point (W m⁻²).
+   :rtype: float
+
+   :raises ValueError: * If the four series differ in length or have fewer than two
+         samples.
+       * If `time_series` is not strictly increasing.
+       * If any element of `cv_series` or `ks_series` is non-positive.
+
+   .. rubric:: Notes
+
+   * The algorithm uses a forward finite-difference for
+     :math:`dT/dt'` and trapezoidal integration over each interval
+     *[t_i, t_{i+1}]*.
+   * Only the latest values of *k_s* and *C_v* are used, consistent
+     with the Hsieh et al. derivation.  Replace with a time-variable
+     kernel if property changes are large over the record.
+   * All inputs are cast to :class:`numpy.ndarray` with
+     ``dtype=float``.
+
+   .. rubric:: References
+
+   Hsieh, C.-I., Katul, G., & Chi, T.-C. (2009).
+   *Retrieval of soil heat flux from soil temperature data by the
+   continuous-time heat equation model.*
+   **Water Resources Research**, 45, W08433.
+   https://doi.org/10.1029/2009WR007891
+
+   .. rubric:: Examples
+
+   >>> times  = np.array([0, 600, 1200, 1800])        # every 10 min
+   >>> temps  = np.array([292.5, 293.0, 293.6, 294.0])  # K
+   >>> Cv     = np.full_like(temps, 2.3e6)            # J m-3 K-1
+   >>> ks     = np.full_like(temps, 1.1e-6)           # m2 s-1
+   >>> hsieh2009_gz(temps, times, Cv, ks)
+   -2.13...
 
 
-.. py:function:: leuning_damping_depth(z, zr, AT_z, AT_zr)
+.. py:function:: leuning_damping_depth(z: numpy.ndarray | float, zr: numpy.ndarray | float, AT_z: numpy.ndarray | float, AT_zr: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Compute damping depth *d* via Eq. (6).
+   Estimate the **thermal damping depth** *d* (m) from the exponential
+   decay of temperature–wave amplitude with depth.
+
+   The formulation is based on Eq. (6) of Leuning *et al.* (1985) for a
+   one-dimensional, sinusoidally forced soil column:
+
+   .. math::
+
+       d \;=\;
+       \frac{z_r - z}{\ln\bigl(A_T(z) / A_T(z_r)\bigr)}
+
+   where
+
+   * :math:`A_T(z)` — amplitude of the temperature wave at depth *z*
+   * :math:`z_r`  — reference depth (m)
+   * :math:`A_T(z_r)` — amplitude at reference depth
+
+   The equation assumes amplitudes decrease monotonically with depth
+   following :math:`A_T(z) = A_T(0)\,\exp(-z/d)`.
+
+   :param z: Depth(s) (m) at which the amplitude *A_T(z)* was measured.
+             Positive values denote depth below the surface.
+   :type z: float or array_like
+   :param zr: Reference depth(s) *z_r* (m).  Must be broadcast-compatible with
+              *z*.  If *zr* < *z* the denominator switches sign, yielding a
+              negative *d* that should be interpreted carefully.
+   :type zr: float or array_like
+   :param AT_z: Temperature-wave amplitude at *z* (K).
+   :type AT_z: float or array_like
+   :param AT_zr: Temperature-wave amplitude at *z_r* (K).
+   :type AT_zr: float or array_like
+
+   :returns: Thermal damping depth *d* (m).  The output shape follows NumPy
+             broadcasting rules applied to the four inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any of the following conditions occur:
+
+       * *AT_z* or *AT_zr* contain non-positive values (log undefined).
+       * *AT_z* and *AT_zr* are equal everywhere, leading to
+         ``ln(1) = 0`` and division by zero.
+       * The inputs cannot be broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Vectorisation** — Internally, all inputs are converted to
+     :class:`~numpy.ndarray`; the formula is applied element-wise and
+     fully supports broadcasting.
+   * **Physical meaning** — Larger *d* indicates slower attenuation of
+     temperature fluctuations with depth (i.e. higher thermal
+     diffusivity or conductivity).  Very small logarithmic denominators
+     (`AT_z` ≈ `AT_zr`) imply an extremely deep damping depth that may
+     fall outside the soil column considered.
+   * **Units** — Depths must share the same units (metres).  Amplitudes
+     may be in kelvins or degrees Celsius provided they use identical
+     scaling.
+
+   .. rubric:: References
+
+   Leuning, R., Barlow, E. W. R., & Paltridge, G. (1985).
+   *Temperature gradients in a soil: Theory and measurement.*
+   *Agricultural and Forest Meteorology*, 35(1–4), 127–143.
+   https://doi.org/10.1016/0168-1923(85)90067-3
+
+   .. rubric:: Examples
+
+   >>> d = leuning_damping_depth(z=0.10, zr=0.05, AT_z=4.0, AT_zr=8.0)
+   >>> round(d, 4)
+   0.0721
+
+   >>> #Broadcasting with arrays
+   >>> depths = np.array([0.05, 0.10, 0.20])
+   >>> amps   = np.array([8.0, 4.0, 1.5])
+   >>> d_arr  = leuning_damping_depth(depths, 0.02, amps, 10.0)
+   >>> d_arr
+   array([0.0380..., 0.0495..., 0.0854...])
 
 
-.. py:function:: leuning_gz(g_zr, z, zr, d)
+.. py:function:: leuning_gz(g_zr: numpy.ndarray | float, z: numpy.ndarray | float, zr: numpy.ndarray | float, d: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Exponentially adjust G_z from reference depth (Eq. 7).
+   Extrapolate **soil heat flux** from a reference depth *z_r* to a
+   shallower (or deeper) target depth *z* using an *exponential
+   attenuation* model (Leuning *et al.* 1985, Eq. 7).
+
+   The model assumes the amplitude of the heat-flux wave decays
+   exponentially with depth at the same *damping depth* **d** that
+   governs temperature attenuation:
+
+   .. math::
+
+       G(z,t) \;=\; G(z_r,t)\;\exp\!\left(\frac{z_r - z}{d}\right)
+
+   where
+   :math:`G(z_r,t)` is the measured flux at *z_r* (W m⁻²).
+
+   :param g_zr: Heat flux measured at reference depth *z_r* (W m⁻²).  Can be a
+                scalar or a NumPy-broadcastable array (e.g. a time series).
+   :type g_zr: float or array_like
+   :param z: Target depth *z* (m, **positive downward**).  Must be broadcast-
+             compatible with *g_zr*.
+   :type z: float or array_like
+   :param zr: Reference depth *z_r* (m, positive downward).  Broadcast
+              compatible with *z*.
+   :type zr: float or array_like
+   :param d: Thermal damping depth (m).  Positive; same shape rules as *z*.
+   :type d: float or array_like
+
+   :returns: Estimated heat flux at depth *z* (W m⁻²).  Follows NumPy
+             broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *d* is non-positive, or if inputs cannot be
+       broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Direction of extrapolation** –
+     *z < z_r* (shallower) ⇒ magnitude *increases* toward the surface;
+     *z > z_r* (deeper)   ⇒ magnitude *decreases* with depth.
+   * **Vectorisation** – Inputs are converted to
+     :class:`numpy.ndarray` and the formula is evaluated element-wise.
+   * **Limitations** – The simple exponential form ignores soil
+     layering and moisture variability; best suited to homogeneous
+     profiles over the depth interval considered.
+
+   .. rubric:: References
+
+   Leuning, R., Barlow, E. W. R., & Paltridge, G. (1985).
+   *Temperature gradients in a soil: Theory and measurement.*
+   **Agricultural and Forest Meteorology**, 35(1–4), 127-143.
+   https://doi.org/10.1016/0168-1923(85)90067-3
+
+   .. rubric:: Examples
+
+   >>> # Single depth conversion
+   >>> leuning_gz(g_zr=-12.0, z=0.05, zr=0.08, d=0.07)
+   -18.841...
+
+   >>> # Vectorized daily time series
+   >>> g_plate = np.random.normal(-10, 3, 1440)      # W m-2 @ 8 cm
+   >>> d       = 0.07                                # m
+   >>> Gz_5cm  = leuning_gz(g_plate, z=0.05, zr=0.08, d=d)
+   >>> Gz_5cm.shape
+   (1440,)
 
 
-.. py:function:: simple_measurement_gz(g_zr, cv_layers, tz_layers, dt, dz_layers)
+.. py:function:: simple_measurement_gz(g_zr: numpy.ndarray | float, cv_layers: numpy.ndarray | float, tz_layers: numpy.ndarray | float, dt: float, dz_layers: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Simple‑measurement variant of calorimetric method (Eq. 8).
+       Ground-heat-flux estimate at a target depth *z* using the
+       **simple-measurement variant** of the *calorimetric* method
+       (Liebethal & Foken 2007, Eq. 8).
+
+       The algorithm corrects a heat-flux‐plate measurement taken at a
+       reference depth *z_r* by adding an approximation of the heat storage
+       change *ΔS* in the soil slab between the plate and the surface,
+       computed from two successive soil-temperature profiles:
+
+       .. math::
+
+           G(z,t_j) \;=\; G(z_r,t_j)
+           \;+\; \sum_{l=1}^{N} C_{v,l}\,\Delta z_l\,
+
+   rac{\Delta T_{l,j} +
+   rac{1}{2}igl(\Delta T_{l,j} - \Delta T_{l,j-1}igr)}
+                       {\Delta t}
+
+       where
+
+       * :math:`C_{v,l}` — volumetric heat capacity of layer *l*
+         (J m⁻³ K⁻¹)
+       * :math:`\Delta z_l` — layer thickness (m)
+       * :math:`\Delta T_{l,j}` — temperature change in layer *l*
+         between *t_{j-1}* and *t_j* (K)
+       * :math:`\Delta t` — measurement interval (s)
+
+       The centred finite-difference term in brackets approximates the
+       mid-interval temperature tendency, providing second-order accuracy
+       from simple time-series measurements (`tz_layers`).
+
+       Parameters
+       ----------
+       g_zr : float or array_like
+           Plate-measured soil heat flux at reference depth *z_r*
+           (W m⁻²).  Length **M** time steps.
+       cv_layers : array_like
+           Volumetric heat capacity for each of *N* soil layers
+           (J m⁻³ K⁻¹).  Shape ``(N,)`` or broadcast-compatible with the
+           first axis of `tz_layers`.
+       tz_layers : array_like
+           Layer-average soil temperatures.  Shape ``(N, M)`` where *N* is
+           the number of layers (matching `cv_layers`/`dz_layers`) and *M*
+           is the number of time stamps (matching `g_zr`).
+       dt : float
+           Constant time step between consecutive temperature samples
+           (s).  Must be positive.
+       dz_layers : array_like
+           Thickness of each layer (m).  Shape ``(N,)`` broadcast-compatible
+           with `cv_layers`.
+
+       Returns
+       -------
+       float or numpy.ndarray
+           Calorimetrically corrected soil heat flux at depth *z*
+           (W m⁻²).  Length **M − 1** because the centred difference
+           requires two successive profiles.
+
+       Raises
+       ------
+       ValueError
+           If input dimensions are inconsistent, `dt` ≤ 0, or any layer
+           arrays contain non-finite values.
+
+       Notes
+       -----
+       * **Temporal alignment** – The first output value corresponds to the
+         mid-point of the first two temperature samples
+         ``t[0] … t[1]``; therefore the result is shifted **½ Δt** relative
+         to the plate-flux time stamps.
+       * **Vectorisation** – All calculations are fully vectorized using
+         NumPy broadcasting.  Inputs are internally cast to
+         :class:`numpy.ndarray`.
+       * **Applicability** – Best suited to homogeneous layers with
+         high-quality temperature measurements at identical timestamps.
+
+       References
+       ----------
+       Liebethal, C., & Foken, T. (2007). *Evaluation of six parameterization
+       approaches for the ground heat flux.* Agricultural and Forest
+       Meteorology, 143(1–2), 65–80.
+       https://doi.org/10.1016/j.agrformet.2006.11.001
+
+       Examples
+       --------
+       >>> g_plate = np.array([-12.3, -10.9, -8.5])      # W m-2 at z_r
+       >>> Cv       = np.array([2.3e6, 2.1e6])           # two layers
+       >>> T        = np.array([[15.0, 15.5, 16.0],      # °C layer 1
+       ...                     [14.0, 14.2, 14.4]])      # °C layer 2
+       >>> dz       = np.array([0.03, 0.02])             # m
+       >>> Gz = simple_measurement_gz(g_plate, Cv, T, dt=1800, dz_layers=dz)
+       >>> Gz
+       array([-10.700...,  -8.317...])
 
 
-.. py:function:: wbz12_g_gz(g_zr_series, time_series, z, zr, k_s_val)
 
-   WBZ12‑G method (Eq. 9–10).
+.. py:function:: wbz12_g_gz(g_zr_series: numpy.ndarray | list | tuple, time_series: numpy.ndarray | list | tuple, z: float, zr: float, k_s_val: float) -> numpy.ndarray
+
+   Estimate **soil heat flux** at a shallow depth *z* from a flux-plate
+   record at reference depth *z_r* using the **WBZ12-G convolution
+   method** (Wang, Bou-Zeid & Zhang 2012, their Eq. 9–10).
+
+   The algorithm inverts the one-dimensional heat-conduction equation
+   for a semi-infinite homogeneous soil, assuming a step-response
+   kernel based on the complementary error function *erfc*:
+
+   .. math::
+
+       G(z,t) \;=\; 2\,G(z_r,t)
+       \;-\; \frac{J(t)}{\Delta F_z(t)}
+
+   with the discrete convolution integral
+
+   .. math::
+
+       J(t_n) \;=\;
+       \sum_{j=0}^{n-1}
+       \tfrac{\bigl[G(z_r,t_{n-j-1}) + G(z_r,t_{n-j})\bigr]}{2}\;
+       \Delta F_z(t_{j+1})
+
+   and the *transfer function increment*
+
+   .. math::
+
+       \Delta F_z(t) =
+       \operatorname{erfc}\!
+       \left[\frac{z_r - z}{2\sqrt{k_s (t - t_0)}}\right]
+       \;-\;
+       \operatorname{erfc}\!
+       \left[\frac{z_r - z}{2\sqrt{k_s (t - t_0 - \Delta t)}}\right].
+
+   :param g_zr_series: Time series of heat-flux-plate measurements at *z_r* (W m⁻²);
+                       length **N**.
+   :type g_zr_series: array_like
+   :param time_series: Monotonically increasing time stamps (s) corresponding to
+                       `g_zr_series`.  Must be the same length **N**.
+   :type time_series: array_like
+   :param z: Target depth (m, **positive downward**).
+   :type z: float
+   :param zr: Reference depth of the heat-flux plate (m, positive downward).
+   :type zr: float
+   :param k_s_val: Soil thermal diffusivity *k_s* (m² s⁻¹).  Must be positive.
+   :type k_s_val: float
+
+   :returns: Estimated heat-flux series at depth *z*, same length **N** as the
+             input series (W m⁻²).
+   :rtype: numpy.ndarray
+
+   :raises ValueError: If `k_s_val ≤ 0`, the two series differ in length, time stamps
+       are non-monotonic, or contain fewer than two samples.
+
+   .. rubric:: Notes
+
+   * The first element of the output corresponds to *t₀* (no storage
+     correction possible yet); subsequent points incorporate the
+     convolution up to that instant.
+   * A very small term ``+ 1e-12`` is added under the square root to
+     avoid division by zero at *t = t₀*.
+   * The complementary error function is evaluated with
+     :func:`numpy.erfc`, which is vectorized and avoids the SciPy
+     dependency.
+
+   .. rubric:: References
+
+   Wang, W., Bou-Zeid, E., & Zhang, Y. (2012).
+   *Estimating surface heat fluxes using the surface renewal method*.
+   **Boundary-Layer Meteorology**, 144(2), 407-422.
+   https://doi.org/10.1007/s10546-012-9730-9
+
+   .. rubric:: Examples
+
+   >>> # 10-min sampled day-long plate record at zr = 0.08 m
+   >>> t  = np.arange(0, 24*3600 + 1, 600)            # s
+   >>> Gp = -10 + 5*np.sin(2*np.pi*t/86400)
+   >>> Gz = wbz12_g_gz(Gp, t, z=0.05, zr=0.08, k_s_val=1.0e-6)
+   >>> Gz.shape
+   (145,)
 
 
-.. py:function:: wbz12_s_gz(Ag, ks_val, zr, z, t, eps, omega=OMEGA_DAY)
+.. py:function:: wbz12_s_gz(Ag: numpy.ndarray | float, ks_val: numpy.ndarray | float, zr: float, z: float, t: numpy.ndarray | float, eps: numpy.ndarray | float, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   WBZ12‑S solution (Eq. 11).
+       **WBZ12-S analytic–numeric solution** for soil heat flux *G(z, t)* at
+       depth *z* (Wang, Bou-Zeid & Zhang 2012, Eq. 11).
 
-   Numerical integration is performed for the second term.
+       WBZ12-S combines a closed-form *forcing* term (sinusoidal surface
+       temperature) with a *storage* term that is expressed as a Fourier‐
+       Laplace integral and must be evaluated numerically.  The governing
+       equation assumes homogeneous soil properties and a sinusoidal
+       surface temperature of amplitude *A_g* and phase `eps`:
+
+       .. math::
+
+           G(z,t) \;=\;
+           A_g\,e^{-\eta}\,\sin\bigl(\omega t +
+   arepsilon - \eta\bigr)
+           \;-\;
+           \frac{2 A_g k_s}{\pi}
+           \int_{0}^{\infty}
+               \frac{
+                   k_s \zeta^{2} igl[\sin\varepsilon
+                   - \omega \cos\varepsilon\bigr]
+                 }{
+                   \omega^{2}
+                   + k_{s}^{2} \zeta^{4}
+               }
+               \sin\bigl[\zeta\,(z_r - z)\bigr]\,
+               e^{-k_s \zeta^{2} t}\,d\zeta
+
+       with
+
+       .. math::
+           \eta \;=\; (z_r - z)\,\sqrt{\omega / (2 k_s)}.
+
+       The first term (prefactor × sin_term) represents the periodic
+       *steady-state* component, while the integral accounts for the
+       *transient* adjustment of the soil profile.
+
+       Parameters
+       ----------
+       Ag : float or array_like
+           Amplitude of the sinusoidal surface/ground temperature (K).  Can
+           be broadcast with `t` and `eps`.
+       ks_val : float or array_like
+           Soil thermal diffusivity :math:`k_s` (m² s⁻¹).  Must be positive.
+       zr : float
+           Reference depth of the heat-flux plate (m, positive downward).
+       z : float
+           Target depth for the output heat flux (m, positive downward).
+       t : float or array_like
+           Time (s) since the start of the forcing cycle.  Broadcast-
+           compatible with `Ag` and `eps`.
+       eps : float or array_like
+           Phase shift :math:`\varepsilon` (rad) of the surface
+           temperature.  Broadcast-compatible with `t`.
+       omega : float, optional
+           Angular frequency :math:`\omega` (rad s⁻¹) of the sinusoidal
+           forcing (default is :pydata:`OMEGA_DAY` ≈ 7.272 × 10⁻⁵ s⁻¹).
+
+       Returns
+       -------
+       float or numpy.ndarray
+           Soil heat flux *G(z, t)* (W m⁻²).  The shape matches NumPy
+           broadcasting over (`Ag`, `ks_val`, `t`, `eps`).
+
+       Raises
+       ------
+       ValueError
+           If *ks_val* or *omega* are non-positive, or if the inputs cannot
+           be broadcast to a common shape.
+
+       Notes
+       -----
+       * **Numerical integral** – The transient term is evaluated using
+         :func:`scipy.integrate.quad` over :math:`\zeta \in [0, \infty)`.
+         The integral can be expensive for long time-series; cache results
+         or vectorise with more sophisticated quadrature if performance is
+         critical.
+       * **Vectorisation** – `quad` is called individually for every
+         element in the broadcasted inputs; large arrays may thus incur
+         heavy computational cost.
+       * **Units** – Use consistent SI units: W m⁻² (output), K (Ag),
+         m² s⁻¹ (ks_val), rad s⁻¹ (omega), seconds (t), metres (depths).
+
+       References
+       ----------
+       Wang, W., Bou-Zeid, E., & Zhang, Y. (2012).
+       *Estimating surface heat fluxes using the surface renewal method.*
+       **Boundary-Layer Meteorology**, 144(2), 407–422.
+       https://doi.org/10.1007/s10546-012-9730-9
+
+       Examples
+       --------
+       >>> # Daily sinusoid, single point
+       >>> G = wbz12_s_gz(
+       ...     Ag=8.0, ks_val=1.0e-6,
+       ...     zr=0.08, z=0.05,
+       ...     t=np.linspace(0, 86400, 97),
+       ...     eps=0.0
+       ... )
+       >>> G.shape
+       (97,)
 
 
-.. py:function:: exact_temperature_gz(z, AT, t, d, omega=OMEGA_DAY, T_i=298.15)
 
-   Exact sinusoidal soil‑temperature profile (Eq. 16).
+.. py:function:: exact_temperature_gz(z: numpy.ndarray | float, AT: numpy.ndarray | float, t: numpy.ndarray | float, d: numpy.ndarray | float, omega: float = OMEGA_DAY, T_i: float = 298.15) -> numpy.ndarray | float
+
+   Compute the **exact analytical soil‐temperature profile**
+   under sinusoidal surface forcing.
+
+   A sinusoidal temperature wave propagating downward through a
+   homogeneous soil decays exponentially with depth and lags in phase.
+   The closed‐form solution at depth *z* (m) is
+
+   .. math::
+
+       T(z, t) \;=\;
+       T_i
+       \;+\;
+       A_T \,
+       e^{-z/d}\,
+       \sin\bigl(\omega t \;-\; z/d\bigr),
+
+   where
+
+   * :math:`T_i` — initial (mean) temperature of the soil column (K)
+   * :math:`A_T` — amplitude of the surface-temperature oscillation (K)
+   * :math:`d` — thermal damping depth (m)
+   * :math:`\omega` — angular frequency of the forcing (rad s⁻¹)
+   * :math:`t` — time since the start of oscillation (s)
+
+   :param z: Depth below the surface (m). Positive downward.  Can be a scalar
+             or an array broadcastable with *t* and *AT*.
+   :type z: float or array_like
+   :param AT: Amplitude *A_T* of the surface temperature wave (K).
+   :type AT: float or array_like
+   :param t: Time variable (s).  Supports vectorisation.
+   :type t: float or array_like
+   :param d: Thermal damping depth (m). Must be positive.  Can be scalar or
+             broadcastable with *z*.
+   :type d: float or array_like
+   :param omega: Angular frequency *ω* (rad s⁻¹). Defaults to
+                 :pydata:`OMEGA_DAY` (≈ 7.272 × 10⁻⁵ s⁻¹ for 24 h).
+   :type omega: float, optional
+   :param T_i: Mean (initial) soil temperature (K).  Defaults to **298.15 K**
+               (25 °C).
+   :type T_i: float, optional
+
+   :returns: Soil temperature *T(z, t)* (same units as *T_i*).  The result
+             shape matches NumPy broadcasting over the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *d* or *omega* is non-positive, or if inputs
+       cannot be broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Phase lag** – Each e-folding depth *d* introduces a phase delay
+     of 1 radian (~57.3 °) relative to the surface signal.
+   * **Vectorisation** – All inputs are converted to
+     :class:`numpy.ndarray`; the formula is evaluated element-wise and
+     fully supports broadcasting.
+   * **Units** – Ensure consistent SI units (metres, seconds, kelvins).
+
+   .. rubric:: References
+
+   Adapted from Gao, Z., Horton, R., Luo, L., & Kucharik, C. J. (2010).
+   *A simple method to measure soil temperature dynamics: Theory and
+   application.* **Soil Science Society of America Journal**, 74(2),
+   580-588. https://doi.org/10.2136/sssaj2009.0169
+
+   .. rubric:: Examples
+
+   >>> # Daily cycle at 10 cm depth
+   >>> z      = 0.10                            # m
+   >>> AT     = 8.0                             # K
+   >>> d      = 0.12                            # m
+   >>> t_day  = np.linspace(0, 86400, 97)       # 15-min resolution
+   >>> Tz     = exact_temperature_gz(z, AT, t_day, d)
+   >>> Tz.shape
+   (97,)
 
 
-.. py:function:: exact_gz(z, AT, lambda_s_val, d, t, omega=OMEGA_DAY)
+.. py:function:: exact_gz(z: numpy.ndarray | float, AT: numpy.ndarray | float, lambda_s_val: numpy.ndarray | float, d: numpy.ndarray | float, t: numpy.ndarray | float, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   Exact sinusoidal soil‑heat‑flux (Eq. 17).
+   Exact analytical **soil-heat-flux** solution for sinusoidal surface forcing.
+
+   A sinusoidal surface–temperature wave of amplitude *A_T* and angular
+   frequency *ω* generates a heat-flux wave that decays exponentially
+   with depth and lags the temperature signal by *π / 4* radians
+   (Gao et al., 2010, Eq. 17):
+
+   .. math::
+
+       G(z,t) \;=\;
+       \sqrt{2}\;
+       \frac{\lambda_s A_T}{d}\;
+       e^{-z/d}\;
+       \sin\bigl(\omega t - z/d + \tfrac{\pi}{4}\bigr)
+
+   where
+
+   * :math:`\lambda_s` — soil thermal conductivity (W m⁻¹ K⁻¹)
+   * :math:`d` — thermal damping depth (m)
+   * :math:`z` — depth below the surface (m, positive downward)
+   * :math:`t` — time (s) since the start of oscillation
+   * :math:`\omega` — angular frequency (rad s⁻¹)
+
+   :param z: Depth(s) below the surface (m), positive downward.
+   :type z: float or array_like
+   :param AT: Amplitude *A_T* of the surface-temperature oscillation (K).
+   :type AT: float or array_like
+   :param lambda_s_val: Soil thermal conductivity *λ_s* (W m⁻¹ K⁻¹).
+   :type lambda_s_val: float or array_like
+   :param d: Thermal damping depth (m). Must be positive.
+   :type d: float or array_like
+   :param t: Time variable (s).
+   :type t: float or array_like
+   :param omega: Angular frequency *ω* (rad s⁻¹). Defaults to
+                 :pydata:`OMEGA_DAY` (≈ 7.272 × 10⁻⁵ s⁻¹, i.e. 2π / 86 400 s).
+   :type omega: float, optional
+
+   :returns: Soil heat flux *G(z, t)* (W m⁻²).  The return shape follows NumPy
+             broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *d* or *omega* is non-positive, or if inputs
+       cannot be broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Phase shift** – At any given depth, the heat-flux wave lags the
+     temperature wave by 45 ° (π / 4 rad).
+   * **Vectorisation** – All inputs are converted to
+     :class:`numpy.ndarray`; the expression is evaluated element-wise
+     and fully supports broadcasting.
+   * **Units** – Ensure all quantities use consistent SI units.
+
+   .. rubric:: References
+
+   Gao, Z., Horton, R., Luo, L., & Kucharik, C. J. (2010).
+   *A simple method to measure soil temperature dynamics: Theory and
+   application.* **Soil Science Society of America Journal**, 74(2),
+   580–588. https://doi.org/10.2136/sssaj2009.0169
+
+   .. rubric:: Examples
+
+   >>> # Scalar example
+   >>> exact_gz(
+   ...     z=0.05,
+   ...     AT=8.0,
+   ...     lambda_s_val=1.2,
+   ...     d=0.12,
+   ...     t=3600,
+   ... )
+   21.52...
+
+   >>> # Vectorized daily cycle
+   >>> t_day = np.linspace(0, 86400, 97)           # 15-min resolution
+   >>> Gz = exact_gz(
+   ...     z=0.10,
+   ...     AT=6.0,
+   ...     lambda_s_val=1.1,
+   ...     d=0.11,
+   ...     t=t_day,
+   ... )
+   >>> Gz.shape
+   (97,)
 
 

--- a/docs/autoapi/soil_heat/index.rst
+++ b/docs/autoapi/soil_heat/index.rst
@@ -5,7 +5,29 @@ soil_heat
 
 .. autoapi-nested-parse::
 
-   Top-level package for Soil Heat.
+   soil_heat: A Python library for soil heat flux models.
+   ======================================================
+
+   This package provides a collection of Python functions for calculating
+   soil heat flux and related soil thermal properties. The implementations
+   are based on various models and parameterizations published in the
+   peer-reviewed scientific literature.
+
+   The library is organized into modules, each corresponding to a specific
+   publication or a set of related equations.
+
+   Available submodules:
+   ---------------------
+   - `soil_heat`: Core functions and utilities.
+   - `gao_et_al`: Functions from Gao et al. (2017).
+   - `liebethal_and_folken`: Functions from Liebethal & Foken (2006).
+   - `wang_and_bouzeid`: Functions from Wang & Bou-Zeid (2012).
+   - `wang_and_yang`: Functions from Yang & Wang (2008).
+   - `fao56_soil_heat_flux`: FAO-56 and ASCE soil heat flux methods.
+   - `storage_calculations`: Soil and canopy heat storage calculations.
+
+   All functions are designed to work with NumPy arrays for efficient,
+   vectorized computations.
 
 
 
@@ -15,9 +37,11 @@ Submodules
 .. toctree::
    :maxdepth: 1
 
+   /autoapi/soil_heat/fao56_soil_heat_flux/index
    /autoapi/soil_heat/gao_et_al/index
    /autoapi/soil_heat/liebethal_and_folken/index
    /autoapi/soil_heat/soil_heat/index
+   /autoapi/soil_heat/storage_calculations/index
    /autoapi/soil_heat/wang_and_bouzeid/index
    /autoapi/soil_heat/wang_and_yang/index
 
@@ -33,6 +57,8 @@ Attributes
    soil_heat.WATER_HEAT_CAPACITY
    soil_heat.df
    soil_heat.surface_energy_residual
+   soil_heat.DEFAULT_CS
+   soil_heat.LATENT_HEAT_INV
 
 
 Functions
@@ -57,6 +83,7 @@ Functions
    soil_heat.calculate_thermal_diffusivity_for_pair
    soil_heat.calculate_thermal_properties_for_all_pairs
    soil_heat.estimate_rhoc_dry
+   soil_heat.calculate_soil_heat_storage
    soil_heat.lambda_s
    soil_heat.k_s
    soil_heat.volumetric_heat_capacity
@@ -109,6 +136,21 @@ Functions
    soil_heat.flux_error_linear
    soil_heat.surface_energy_residual
    soil_heat.tdec_step
+   soil_heat.soil_heat_flux_general
+   soil_heat.soil_heat_flux_daily
+   soil_heat.soil_heat_flux_monthly
+   soil_heat.soil_heat_flux_monthly_prev_only
+   soil_heat.soil_heat_flux_hourly
+   soil_heat.soil_heat_flux_hourly_auto
+   soil_heat.soil_heat_flux_monthly_series
+   soil_heat.soil_heat_flux_annual_cycle
+   soil_heat.energy_to_evap
+   soil_heat.evap_to_energy
+   soil_heat.mj_m2_day_to_w_m2
+   soil_heat.w_m2_to_mj_m2_day
+   soil_heat._run_tests
+   soil_heat.compute_soil_storage_integrated
+   soil_heat.compute_canopy_storage
 
 
 Package Contents
@@ -123,7 +165,7 @@ Package Contents
 
 
 .. py:data:: __version__
-   :value: '0.1.0'
+   :value: '0.1.1'
 
 
 .. py:data:: WATER_HEAT_CAPACITY
@@ -354,28 +396,58 @@ Package Contents
 
 .. py:function:: soil_heat_flux(T_upper, T_lower, depth_upper, depth_lower, k)
 
-   Calculate soil heat flux (G) using temperature gradient and thermal conductivity.
+   Calculate soil heat flux (G) using Fourier's law of heat conduction.
 
-   Parameters:
-   - T_upper: Temperature at upper depth (°C)
-   - T_lower: Temperature at lower depth (°C)
-   - depth_upper: Upper sensor depth (m)
-   - depth_lower: Lower sensor depth (m)
-   - k: Thermal conductivity (W/(m·°C))
+   This function computes the one-dimensional heat flux in the soil based on
+   the temperature gradient between two depths and the soil's thermal
+   conductivity. The formula used is:
 
-   Returns:
-   - Soil heat flux (W/m^2)
+   .. math::
+
+       G = -k \frac{\Delta T}{\Delta z}
+
+   where :math:`G` is the soil heat flux, :math:`k` is the thermal
+   conductivity, :math:`\Delta T` is the temperature difference, and
+   :math:`\Delta z` is the distance between the two measurement depths.
+
+   :param T_upper: Temperature at the upper depth (°C or K).
+   :type T_upper: float or array_like
+   :param T_lower: Temperature at the lower depth (°C or K).
+   :type T_lower: float or array_like
+   :param depth_upper: Depth of the upper sensor (m, positive downward).
+   :type depth_upper: float
+   :param depth_lower: Depth of the lower sensor (m, positive downward).
+   :type depth_lower: float
+   :param k: Thermal conductivity of the soil layer between the sensors (W m⁻¹ K⁻¹).
+   :type k: float or array_like
+
+   :returns: The calculated soil heat flux (W m⁻²). A positive value indicates
+             a downward flux (from the surface into the soil).
+   :rtype: float or array_like
 
 
 .. py:function:: volumetric_heat_capacity(theta_v)
 
-   Estimate volumetric heat capacity Cv (J/(m³·°C)) from soil moisture.
+   Estimate volumetric heat capacity (Cv) from soil moisture content.
 
-   Parameters:
-   - theta_v: Volumetric water content (decimal fraction, e.g., 0.20 for 20%)
+   This function uses a simple mixing model to estimate the volumetric heat
+   capacity of moist soil. It assumes the soil is a two-component mixture
+   of dry soil and water. The formula is:
 
-   Returns:
-   - Volumetric heat capacity (kJ/(m³·°C))
+   .. math::
+
+       C_v = (1 - \theta_v) C_{soil} + \theta_v C_{water}
+
+   where :math:`\theta_v` is the volumetric water content, and
+   :math:`C_{soil}` and :math:`C_{water}` are the volumetric heat
+   capacities of dry soil and water, respectively.
+
+   :param theta_v: Volumetric water content (m³ m⁻³). This is a decimal fraction,
+                   e.g., 0.20 for 20% water content.
+   :type theta_v: float or array_like
+
+   :returns: The estimated volumetric heat capacity (kJ m⁻³ K⁻¹).
+   :rtype: float or array_like
 
 
 .. py:function:: thermal_conductivity(alpha: numpy.ndarray | float, theta_v: numpy.ndarray | float) -> numpy.ndarray | float
@@ -394,7 +466,7 @@ Package Contents
    * *α* – thermal diffusivity (m² s⁻¹),
    * *C_v(θ_v)* – volumetric heat capacity (J m⁻³ K⁻¹) as a function of
      volumetric water content *θ_v* (m³ m⁻³).
-     It is obtained from :pyfunc:`volumetric_heat_capacity`.
+     It is obtained from :func:`volumetric_heat_capacity`.
 
    :param alpha: Thermal diffusivity **α** (m² s⁻¹).  May be scalar or any
                  NumPy‐broadcastable shape.
@@ -411,7 +483,7 @@ Package Contents
    .. rubric:: Notes
 
    * **Volumetric heat capacity model** –
-     :pyfunc:`volumetric_heat_capacity` typically assumes a two‐phase
+     :func:`volumetric_heat_capacity` typically assumes a two‐phase
      mixture of mineral soil and water:
 
      .. math::
@@ -772,18 +844,38 @@ Package Contents
 
 .. py:function:: thermal_diffusivity_lag(delta_t, z1, z2, period=86400)
 
-   Estimate thermal diffusivity from phase lag.
+   Estimate soil thermal diffusivity (α) from the phase lag of a temperature wave.
 
-   Parameters:
-   - delta_t: Time lag between peaks at two depths (seconds)
-   - z1, z2: Depths (m)
-   - period: Time period of wave (default = 86400 s for daily cycle)
+   This method calculates thermal diffusivity based on the time it takes for a
+   temperature wave (e.g., the diurnal cycle) to travel between two depths in
+   the soil. The formula is derived from the analytical solution to the
+   one-dimensional heat conduction equation for a periodic boundary condition:
 
-   Returns:
-   - Thermal diffusivity α (m²/s)
+   .. math::
 
-   Citation:
-   S.V. Nerpin, and A.F. Chudnovskii, Soil physics, (Moscow: Nauka) p 584, 1967 (in Russian)
+       \alpha = \frac{P (z_2 - z_1)^2}{4 \pi (\Delta t)^2}
+
+   where :math:`P` is the period of the wave, :math:`(z_2 - z_1)` is the
+   distance between the sensors, and :math:`\Delta t` is the time lag of
+   the temperature peak between the two depths.
+
+   :param delta_t: Time lag between the temperature peaks at two depths (seconds).
+   :type delta_t: float or array_like
+   :param z1: Depth of the upper sensor (m, positive downward).
+   :type z1: float
+   :param z2: Depth of the lower sensor (m, positive downward).
+   :type z2: float
+   :param period: The period of the temperature wave (seconds). The default is 86400,
+                  which corresponds to the daily (diurnal) cycle.
+   :type period: int, optional
+
+   :returns: The calculated thermal diffusivity (α) in m² s⁻¹.
+   :rtype: float or array_like
+
+   .. rubric:: References
+
+   Nerpin, S.V., and Chudnovskii, A.F. (1967). *Soil physics*.
+   (Moscow: Nauka) p 584. (In Russian)
 
 
 .. py:function:: thermal_diffusivity_logrithmic(t1z1: float, t2z1: float, t3z1: float, t4z1: float, t1z2: float, t2z2: float, t3z2: float, t4z2: float, z1: float, z2: float, period: int = 86400) -> float
@@ -893,7 +985,7 @@ Package Contents
    The function extracts the **first four consecutive samples** from two
    temperature records—one at the shallow depth ``z1`` and one at the deeper
    depth ``z2``—and passes them to
-   :pyfunc:`thermal_diffusivity_logrithmic`.  That helper implements the
+   :func:`thermal_diffusivity_logrithmic`.  That helper implements the
    log–ratio solution of the 1-D heat‐conduction equation for a sinusoidal
    boundary condition (Horton et al., 1934; de Vries, 1963):
 
@@ -986,7 +1078,7 @@ Package Contents
    equation for a homogeneous medium subject to sinusoidal forcing
    (Carslaw & Jaeger, 1959).
 
-   .. method:: \*\*1. Log-Amplitude (α\_log)**
+   .. method:: 1. Log-Amplitude (α\_log)
 
       Uses the decay of the harmonic amplitude with depth:
 
@@ -996,7 +1088,7 @@ Package Contents
                                    {2\,P\;\ln\bigl(A_1 / A_2\bigr)}
 
 
-   .. method:: \*\*2. Amplitude Ratio (α\_amp)**
+   .. method:: 2. Amplitude Ratio (α\_amp)
 
       Algebraically identical to the log-amplitude method but expressed
       directly in terms of the two amplitudes:
@@ -1009,7 +1101,7 @@ Package Contents
       where ``ω = 2π / P`` is the angular frequency.
 
 
-   .. method:: \*\*3. Phase Lag (α\_lag)**
+   .. method:: 3. Phase Lag (α\_lag)
 
       Relates the travel time (phase shift) of the temperature wave:
 
@@ -1094,12 +1186,12 @@ Package Contents
    *(z₁, z₂)* it
 
    1. Derives thermal diffusivity ``α`` with
-      :pyfunc:`calculate_thermal_diffusivity_for_pair`.
+      :func:`calculate_thermal_diffusivity_for_pair`.
    2. Converts ``α`` to thermal conductivity ``k`` via
-      :pyfunc:`thermal_conductivity`, using the mean volumetric water-
+      :func:`thermal_conductivity`, using the mean volumetric water-
       content of the two layers.
    3. Estimates instantaneous soil heat flux ``G`` by calling
-      :pyfunc:`soil_heat_flux`.
+      :func:`soil_heat_flux`.
 
    Results are returned in a *tidy*, hierarchical ``DataFrame`` whose
    outermost index encodes the depth pair (e.g. ``'0.05-0.10'``).
@@ -1125,7 +1217,7 @@ Package Contents
              inner index matches the *datetime* index of ``df`` (after
              dropping rows with *any* missing data).  For each analysis
              “method” returned by
-             :pyfunc:`calculate_thermal_diffusivity_for_pair` (keys of its
+             :func:`calculate_thermal_diffusivity_for_pair` (keys of its
              result dict) the following columns are present:
 
              ========  ==============================================================
@@ -1143,7 +1235,7 @@ Package Contents
      consistent sample support for derived quantities.
    * **Extensibility** – Additional diffusivity algorithms can be
      integrated by returning extra key–value pairs from
-     :pyfunc:`calculate_thermal_diffusivity_for_pair`; they will be
+     :func:`calculate_thermal_diffusivity_for_pair`; they will be
      propagated automatically.
    * **Performance** – The loop scales *O(n²)* with the number of
      depths.  For large sensor arrays, filter the pairs of interest
@@ -1237,295 +1329,1629 @@ Package Contents
    :value: None
 
 
+.. py:function:: calculate_soil_heat_storage(df, depths, porosity=0.45, bulk_density=1.3)
+
+   Calculate soil heat storage and heat flux.
+
+   Parameters:
+   -----------
+   df : DataFrame
+       Must contain columns: 'T_5cm', 'T_10cm', etc. and 'SM_5cm', 'SM_10cm', etc.
+       where SM is volumetric soil moisture (0-1 or 0-100%)
+   depths : list
+       Measurement depths in cm, e.g., [5, 10, 20, 30, 40, 50]
+   porosity : float
+       Soil porosity (0-1), default 0.45
+   bulk_density : float
+       Dry soil bulk density (g/cm³), default 1.3
+
+   Returns:
+   --------
+   DataFrame with heat storage and flux values
+
+
 .. py:function:: lambda_s(theta: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Thermal conductivity (λ_s) as a function of volumetric water content θ.
+   Compute the **soil thermal conductivity** :math:`\lambda_s`
+   as a function of volumetric water content (θ).
 
-   Implements Eq. (12) from Gao et al. (2017) fileciteturn1file3.
+   The relationship is taken from Gao et al. (2017, Eq. 12):
+
+   .. math::
+
+       \lambda_s(\theta) = 0.20 + \exp\bigl[\,1.46\,(\theta - 0.34)\bigr]
+
+   :param theta: Volumetric water content (m³ m⁻³).
+                 Accepts a scalar value or any array-like object that can be
+                 converted to a :class:`numpy.ndarray`. Values should lie in the
+                 closed interval ``[0, 1]``.
+   :type theta: float or array_like
+
+   :returns: Soil thermal conductivity λ\_s in W m⁻¹ K⁻¹.  The returned type
+             matches the input: a scalar is returned for a scalar *θ*, and a
+             NumPy array for array-like *θ*.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *θ* is outside the physically meaningful
+       range ``[0, 1]``.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – The function is fully vectorized; it operates
+     element-wise on NumPy arrays and broadcasts according to NumPy
+     broadcasting rules.
+   * **Empirical limits** – Gao et al. recommend the equation for
+     mineral soils where 0 ≤ θ ≤ 0.5. Extrapolation beyond this range
+     may introduce error.
+   * **Units** – The output uses SI units (W m⁻¹ K⁻¹).
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   **Soil thermal conductivity parameterization: A closed-form
+   equation and its evaluation.** *Journal of Geophysical Research:
+   Atmospheres*, 122(6), 3466–3478.
+   DOI: 10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> lambda_s(0.25)
+   0.463...
+   >>> import numpy as np
+   >>> theta = np.linspace(0, 0.5, 5)
+   >>> lambda_s(theta)
+   array([0.20      , 0.31243063, 0.41172297, 0.51210322, 0.61861198])
 
 
 .. py:function:: k_s(theta: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Thermal diffusivity (k_s) as a function of volumetric water content θ.
+   Calculate the **soil thermal diffusivity** :math:`k_s`
+   as a function of volumetric water content (θ).
 
-   Implements Eq. (13) from Gao et al. (2017) fileciteturn1file6.
+   The empirical relationship follows Gao et al. (2017, Eq. 13):
+
+   .. math::
+
+       k_s(\theta) = \bigl[0.69 + \exp\bigl(3.06\,(\theta - 0.26)\bigr)\bigr] \times 10^{-7}
+
+   :param theta: Volumetric water content (m³ m⁻³).
+                 Accepts a scalar or any array-like sequence convertible to a
+                 :class:`numpy.ndarray`. Values **must** lie in the closed
+                 interval ``[0, 1]``.
+   :type theta: float or array_like
+
+   :returns: Soil thermal diffusivity *k\_s* in m² s⁻¹.
+             A scalar is returned if *θ* is a scalar; otherwise a NumPy array
+             of matching shape is returned.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *θ* is outside the physically meaningful
+       range ``[0, 1]``.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – The calculation is fully vectorized and
+     broadcasts according to NumPy rules.
+   * **Applicability** – Gao et al. derived this expression for mineral
+     soils under typical field conditions. Extrapolating beyond
+     0 ≤ θ ≤ 0.5 may reduce accuracy.
+   * **Units** – Output is in SI units (m² s⁻¹).
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   *Soil thermal conductivity parameterization: A closed-form equation
+   and its evaluation.* Journal of Geophysical Research: Atmospheres,
+   **122**(6), 3466–3478. https://doi.org/10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> k_s(0.25)
+   1.321...e-07
+   >>> thetas = np.linspace(0, 0.5, 6)
+   >>> k_s(thetas)
+   array([1.14...e-07, 1.21...e-07, 1.30...e-07, 1.41...e-07,
+          1.54...e-07, 1.69...e-07])
 
 
-.. py:function:: volumetric_heat_capacity(lambda_s_val, k_s_val)
+.. py:function:: volumetric_heat_capacity(lambda_s_val: numpy.ndarray | float, k_s_val: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Volumetric heat capacity C_v = λ_s / k_s (units J m⁻³ K⁻¹).
+   Compute the **volumetric heat capacity** :math:`C_v` of soil:
+
+   .. math::
+
+       C_v \;=\; \frac{\lambda_s}{k_s}
+
+   where
+   :math:`\lambda_s` is the **thermal conductivity** (W m⁻¹ K⁻¹) and
+   :math:`k_s` is the **thermal diffusivity** (m² s⁻¹).
+
+   The resulting heat capacity has units of J m⁻³ K⁻¹.
+
+   :param lambda_s_val: Soil thermal conductivity (W m⁻¹ K⁻¹). May be a scalar or any
+                        array-like structure broadcastable with *k_s_val*.
+   :type lambda_s_val: float or array_like
+   :param k_s_val: Soil thermal diffusivity (m² s⁻¹). Must be positive. Accepts a
+                   scalar or array-like input.
+   :type k_s_val: float or array_like
+
+   :returns: Volumetric heat capacity *C_v* (J m⁻³ K⁻¹).  The return type
+             matches the input: a scalar for scalar inputs, or a NumPy array
+             for array-like inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element in *k_s_val* is zero or negative, which would
+       lead to division by zero or non-physical results.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – The function is fully vectorized; both inputs
+     are converted to :class:`numpy.ndarray` and follow NumPy
+     broadcasting rules.
+   * **Physical meaning** – Volumetric heat capacity represents the
+     energy required to raise the temperature of a unit volume of soil
+     by one kelvin. High values correspond to moist or water-logged
+     soils; dry mineral soils have lower *C_v*.
+
+   .. rubric:: Examples
+
+   >>> #Scalar inputs
+   >>> volumetric_heat_capacity(0.8, 1.2e-6)
+   666666.666...
+
+   >>> #Vectorized inputs
+   >>> lambda_vals = np.array([0.5, 0.6, 0.7])
+   >>> diffusivities = np.array([1.1e-6, 1.2e-6, 1.3e-6])
+   >>> volumetric_heat_capacity(lambda_vals, diffusivities)
+   array([454545.4545..., 500000.    ..., 538461.5384...])
 
 
-.. py:function:: nme(calc: numpy.ndarray, meas: numpy.ndarray) -> float
+.. py:function:: nme(calc: numpy.ndarray | float, meas: numpy.ndarray | float) -> float
 
-   Normalized mean error (%). Implements Eq. (14) fileciteturn1file8.
+   Calculate the **normalized mean error (NME)** between calculated
+   and measured values, expressed as a percentage.
+
+   The formulation follows Gao et al. (2017, Eq. 14):
+
+   .. math::
+
+       \text{NME} \;=\; 100\,\frac{\sum\limits_{i}\left|\hat{y}_i - y_i\right|}
+                                     {\sum\limits_{i}\left|y_i\right|}
+
+   where :math:`\hat{y}_i` are the *calculated* (model) values and
+   :math:`y_i` are the *measured* (reference) values.
+
+   :param calc: Modelled / calculated values :math:`\hat{y}`.
+                Accepts any array-like object (including scalars) convertible to
+                a :class:`numpy.ndarray`.
+   :type calc: float or array_like
+   :param meas: Measured / observed reference values :math:`y`. Must be
+                broadcast-compatible with *calc*.
+   :type meas: float or array_like
+
+   :returns: Normalized mean error (percent).
+             A value of **0 %** indicates perfect agreement; larger values
+             indicate greater error.
+   :rtype: float
+
+   :raises ValueError: * If *calc* and *meas* cannot be broadcast to a common shape.
+       * If the denominator ``Σ|meas|`` equals zero (e.g., all measured
+         values are zero), which would make NME undefined.
+
+   .. rubric:: Notes
+
+   * **Range** – NME is non-negative and unbounded above.
+   * **Interpretation** – Because both numerator and denominator use
+     absolute values, NME is insensitive to the direction of the error
+     (over- vs under-prediction) and therefore complements signed error
+     metrics such as mean bias.
+   * **Vectorization** – The implementation is fully vectorized and
+     adheres to NumPy broadcasting rules.
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   *Soil thermal conductivity parameterization: A closed-form equation
+   and its evaluation.* **Journal of Geophysical Research:
+   Atmospheres**, 122(6), 3466–3478.
+   https://doi.org/10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> # Single values
+   >>> nme(4.5, 5.0)
+   10.0
+
+   >>> # Vectors
+   >>> calc = np.array([1.0, 2.1, 3.2])
+   >>> meas = np.array([1.2, 2.0, 3.0])
+   >>> nme(calc, meas)
+   4.7619...
+
+   >>> # Broadcasting (scalar vs array)
+   >>> nme(2.0, np.array([1.5, 2.5, 2.0]))
+   16.6666...
 
 
-.. py:function:: rmse(calc: numpy.ndarray, meas: numpy.ndarray) -> float
+.. py:function:: rmse(calc: numpy.ndarray | float, meas: numpy.ndarray | float) -> float
 
-   Root‑mean‑square error. Implements Eq. (15) fileciteturn1file8.
+   Compute the **root-mean-square error (RMSE)** between calculated
+   (model) and measured (reference) values.
+
+   Following Gao et al. (2017, Eq. 15):
+
+   .. math::
+
+       \text{RMSE} \;=\;
+       \sqrt{\frac{1}{N}\sum_{i=1}^{N}\bigl(\hat{y}_i - y_i\bigr)^2}
+
+   where :math:`\hat{y}_i` are *calculated* values and
+   :math:`y_i` are *measured* values.
+
+   :param calc: Calculated / modelled values :math:`\hat{y}`.  Accepts a scalar
+                or any array-like object convertible to a
+                :class:`numpy.ndarray`.
+   :type calc: float or array_like
+   :param meas: Measured / observed values :math:`y`. Must be broadcast-
+                compatible with *calc*.
+   :type meas: float or array_like
+
+   :returns: Root-mean-square error (same units as the inputs).
+   :rtype: float
+
+   :raises ValueError: * If *calc* and *meas* cannot be broadcast to a common shape.
+       * If the input arrays are empty (``N = 0``).
+
+   .. rubric:: Notes
+
+   * **Interpretation** – RMSE represents the sample-standard-deviation
+     of the differences between two datasets; lower values indicate
+     better agreement.
+   * **Vectorization** – The function is fully vectorized and respects
+     NumPy broadcasting rules.
+   * **Units** – RMSE preserves the units of the input variables.
+
+   .. rubric:: References
+
+   Gao, Z., Niu, G.-Y., & Hedquist, B. C. (2017).
+   *Soil thermal conductivity parameterization: A closed-form equation
+   and its evaluation.* Journal of Geophysical Research:
+   Atmospheres, **122**(6), 3466–3478.
+   https://doi.org/10.1002/2016JD025992
+
+   .. rubric:: Examples
+
+   >>> # Scalar inputs
+   >>> rmse(4.5, 5.0)
+   0.5
+
+   >>> # Vector inputs
+   >>> calc = np.array([2.1, 3.0, 4.2])
+   >>> meas = np.array([2.0, 3.5, 4.0])
+   >>> rmse(calc, meas)
+   0.2645...
+
+   >>> # Broadcasting
+   >>> rmse(3.0, np.array([2.5, 3.5, 3.0]))
+   0.4082...
 
 
-.. py:function:: calorimetric_gz(g_zr, cv_layers, dT_dt_layers, dz_layers)
+.. py:function:: calorimetric_gz(g_zr: numpy.ndarray | float, cv_layers: numpy.ndarray | float, dT_dt_layers: numpy.ndarray | float, dz_layers: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Calorimetric method for G_z at depth z (usually 5 cm).
+   Estimate the **soil heat flux** at a target depth *z*
+   (typically 5 cm) using the *calorimetric method*.
 
-   :param g_zr: Measured heat flux at reference depth *z_r* (W m⁻²).
+   The method corrects an in-situ heat-flux plate reading made at a
+   reference depth *z_r* by adding the change in heat storage of the
+   soil column located between *z* and *z_r*.  Mathematically
+   (Liebethal & Foken 2007, Eq. 1):
+
+   .. math::
+
+       G(z,t) \;=\; G(z_r,t) \;+\;
+       \sum_{l=1}^{N}
+       C_{v,l}\,\frac{\partial \bar{T}_l}{\partial t}\,\Delta z_l
+
+   where
+
+   * :math:`G(z,t)`     … heat flux at depth *z* (W m⁻²)
+   * :math:`G(z_r,t)`   … measured plate flux at reference depth *z_r*
+   * :math:`C_{v,l}`    … volumetric heat capacity of layer *l*
+     (J m⁻³ K⁻¹)
+   * :math:`\partial \bar{T}_l / \partial t` … time derivative of the
+     layer-averaged temperature (K s⁻¹)
+   * :math:`\Delta z_l` … thickness of layer *l* (m)
+
+   :param g_zr: Heat-flux plate measurement at depth *z_r* (W m⁻²).  Can be a
+                scalar or time series.
    :type g_zr: float or array_like
-   :param cv_layers: Volumetric heat capacity for each sub‑layer *C_v,l* (J m⁻³ K⁻¹).
-   :type cv_layers: sequence
-   :param dT_dt_layers: Time derivative of average temperature for each layer ∂T/∂t (K s⁻¹).
-   :type dT_dt_layers: sequence
-   :param dz_layers: Thickness of each sub‑layer δz_l (m).
-   :type dz_layers: sequence
+   :param cv_layers: Volumetric heat capacity :math:`C_{v,l}` for each of *N* soil
+                     sub-layers (J m⁻³ K⁻¹).  Shape ``(N, …)`` where the trailing
+                     dimensions (``…``) must be broadcast-compatible with *g_zr*.
+   :type cv_layers: array_like
+   :param dT_dt_layers: Time derivative of layer-mean temperature
+                        :math:`\partial \bar{T}_l / \partial t`
+                        (K s⁻¹); same shape as *cv_layers*.
+   :type dT_dt_layers: array_like
+   :param dz_layers: Thickness of each layer :math:`\Delta z_l` (m); shape ``(N,)``
+                     or broadcast-compatible with the first axis of *cv_layers*.
+   :type dz_layers: array_like
+
+   :returns: Calorimetrically corrected soil heat flux *G(z)* (W m⁻²).  Scalar
+             if all inputs are scalar; otherwise a NumPy array matching the
+             broadcast shape of *g_zr*.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If the inputs cannot be broadcast to a common shape, or if the
+       number of layers inferred from *cv_layers*, *dT_dt_layers*, and
+       *dz_layers* are inconsistent.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – All operations are fully vectorized.  Inputs
+     are converted to :class:`numpy.ndarray` and follow NumPy
+     broadcasting rules.
+   * **Layer axis** – The first dimension of *cv_layers* and
+     *dT_dt_layers* (axis 0) is interpreted as the layer index *l*.
+     Layer thicknesses *dz_layers* are broadcast across any additional
+     dimensions.
+   * **Units** – Ensure consistent SI units: W m⁻², J m⁻³ K⁻¹,
+     K s⁻¹, and m.
+
+   .. rubric:: References
+
+   Liebethal, C., & Foken, T. (2007). *Evaluation of six parameterization
+   approaches for the ground heat flux.* Agricultural and Forest
+   Meteorology, **143**(1–2), 65-80.
+   https://doi.org/10.1016/j.agrformet.2006.11.001
+
+   .. rubric:: Examples
+
+   >>> # Three-layer example, single time step
+   >>> g_plate = -15.2                      # W m-2 at z_r = −0.05 m
+   >>> Cv     = np.array([2.5e6, 2.3e6, 2.1e6])   # J m-3 K-1
+   >>> dTdt   = np.array([1.2e-4, 0.9e-4, 0.6e-4])  # K s-1
+   >>> dz     = np.array([0.02, 0.02, 0.01])       # m
+   >>> calorimetric_gz(g_plate, Cv, dTdt, dz)
+   -4.06...
+
+   >>> # Vectorized daily time series with two layers
+   >>> g_plate = np.random.normal(-10, 2, 1440)        # per minute
+   >>> Cv       = np.array([[2.4e6], [2.2e6]])         # (2,1)
+   >>> dTdt     = np.random.normal(5e-5, 2e-5, (2,1440))
+   >>> dz       = np.array([0.03, 0.02])
+   >>> Gz = calorimetric_gz(g_plate, Cv, dTdt, dz)     # shape (1440,)
 
 
-.. py:function:: force_restore_gz(cv, dTg_dt, Tg, Tg_bar, delta_z=0.05, omega=OMEGA_DAY)
+.. py:function:: force_restore_gz(cv: numpy.ndarray | float, dTg_dt: numpy.ndarray | float, Tg: numpy.ndarray | float, Tg_bar: numpy.ndarray | float, delta_z: float = 0.05, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   Force‑restore estimate of G_z at z = δz (default 5 cm).
+   Estimate **soil heat flux** :math:`G(z)` at a shallow depth
+   (:math:`z = \delta z`, default 5 cm) with the **force–restore
+   method**.
 
-   Implements Eq. (2) fileciteturn1file2.
+   The formulation (Liebethal & Foken 2007, Eq. 2) corrects the
+   calorimetric storage term with a *restore* component that accounts
+   for the difference between the instantaneous ground temperature
+   *T_g* and its running mean *\bar{T}_g*:
+
+   .. math::
+
+       G(z,t) \;=\; C_v \, \delta z \, \frac{\partial T_g}{\partial t}
+       \;+
+       \sqrt{\omega \, C_v \, \lambda_s(C_v)}
+       \left[
+           \frac{1}{\omega}\,\frac{\partial T_g}{\partial t}
+           + \bigl(T_g - \bar{T}_g\bigr)
+       \right]
+
+   where
+
+   * :math:`C_v`   … volumetric heat capacity (J m⁻³ K⁻¹)
+   * :math:`\partial T_g / \partial t` … ground-temperature tendency
+     (K s⁻¹)
+   * :math:`\lambda_s(C_v)` … soil thermal conductivity derived from
+     *C_v* via :func:`lambda_s_from_cv` (W m⁻¹ K⁻¹)
+   * :math:`\omega` … angular frequency of the diurnal cycle
+     (rad s⁻¹)
+   * :math:`T_g` / :math:`\bar{T}_g` … instantaneous and running-mean
+     ground temperature (K)
+   * :math:`\delta z` … sensor depth below the surface (m)
+
+   :param cv: Volumetric heat capacity :math:`C_v` (J m⁻³ K⁻¹).  Must be
+              positive.  Accepts scalars or NumPy-broadcastable arrays.
+   :type cv: float or array_like
+   :param dTg_dt: Time derivative :math:`\partial T_g/\partial t` (K s⁻¹).
+   :type dTg_dt: float or array_like
+   :param Tg: Instantaneous ground (surface) temperature :math:`T_g` (K or °C)
+              at depth *δz*.
+   :type Tg: float or array_like
+   :param Tg_bar: Running mean ground temperature :math:`\bar{T}_g` over the
+                  diurnal cycle (same units as *Tg*).
+   :type Tg_bar: float or array_like
+   :param delta_z: Depth :math:`\delta z` in metres; default is **0.05 m**
+                   (5 cm).
+   :type delta_z: float, optional
+   :param omega: Angular frequency :math:`\omega` in rad s⁻¹.  Defaults to
+                 :pydata:`OMEGA_DAY` (2π / 86 400 s).
+   :type omega: float, optional
+
+   :returns: Soil heat flux *G(z)* at depth *δz* (W m⁻²).  The output shape
+             follows NumPy broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any input arrays cannot be broadcast to a common shape, or if
+       *cv* contains non-positive values.
+
+   .. rubric:: Notes
+
+   * **λ_s(C_v) mapping** – The function relies on a helper
+     :func:`lambda_s_from_cv` that converts volumetric heat capacity
+     to thermal conductivity.  Ensure that this helper is present in
+     the import path.
+   * **Units** – Keep units internally consistent (SI).
+   * **Vectorization** – All operations are vectorized; the
+     mathematical expression is evaluated element-wise for array
+     inputs.
+   * **Interpretation** – The first term represents *storage*
+     (calorimetric), while the second tempers short-term fluctuations,
+     “restoring” *T_g* toward its mean.
+
+   .. rubric:: References
+
+   Liebethal, C., & Foken, T. (2007). *Evaluation of six
+   parameterization approaches for the ground heat flux.*
+   **Agricultural and Forest Meteorology**, 143(1–2), 65-80.
+   https://doi.org/10.1016/j.agrformet.2006.11.001
+
+   .. rubric:: Examples
+
+   >>> Cv      = 2.4e6                 # J m-3 K-1
+   >>> dTgdt   = 1.0e-4                # K s-1
+   >>> Tg      = 293.5                 # K
+   >>> Tg_bar  = 291.7                 # K (running mean)
+   >>> force_restore_gz(Cv, dTgdt, Tg, Tg_bar)
+   19.3...   # W m-2
+
+   >>> #Vectorized daily record
+   >>> cv_arr = np.full(1440, 2.2e6)
+   >>> dT_arr = np.gradient(np.sin(np.linspace(0, 2*np.pi, 1440))) / 60
+   >>> Gz_ts  = force_restore_gz(cv_arr, dT_arr, 298+2*np.sin(...),
+   ...                           298*np.ones_like(dT_arr))
 
 
-.. py:function:: gao2010_gz(AT, lambda_s_val, k_s_val, t, omega=OMEGA_DAY)
+.. py:function:: gao2010_gz(AT: numpy.ndarray | float, lambda_s_val: numpy.ndarray | float, k_s_val: numpy.ndarray | float, t: numpy.ndarray | float, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   Sinusoidal solution for G_z at depth d (Eq. 3).
+   Estimate **soil heat flux** :math:`G(z,t)` at depth *z* based on a
+   *sinusoidal* ground-temperature forcing (Gao et al. 2010, Eq. 3).
+
+   The analytical solution assumes that the surface (or ground-contact)
+   temperature varies sinusoidally with amplitude *A_T* and angular
+   frequency *ω*.  Under these conditions the heat flux at any depth
+   *z* can be written
+
+   .. math::
+
+       G(z,t) \;=\;
+       \sqrt{2}\,
+       \frac{\lambda_s A_T}{d}\,
+       \sin\bigl(\omega t + \tfrac{\pi}{4}\bigr),
+
+   where the **thermal damping depth**
+
+   .. math::
+
+       d \;=\; \sqrt{\frac{2 k_s}{\omega}}
+
+   is determined by the soil thermal diffusivity *k_s* and the forcing
+   frequency *ω*.
+
+   :param AT: Amplitude of the sinusoidal ground-surface temperature (K).
+   :type AT: float or array_like
+   :param lambda_s_val: Soil thermal conductivity :math:`\lambda_s` (W m⁻¹ K⁻¹).
+   :type lambda_s_val: float or array_like
+   :param k_s_val: Soil thermal diffusivity :math:`k_s` (m² s⁻¹).
+   :type k_s_val: float or array_like
+   :param t: Time variable (s).  Can be absolute time since epoch or simply
+             seconds since the start of the cycle—as long as *ω t* is
+             dimensionless.
+   :type t: float or array_like
+   :param omega: Angular frequency *ω* (rad s⁻¹).  Defaults to *OMEGA_DAY*
+                 (≈ 7.272 × 10⁻⁵ s⁻¹, i.e. 2π / 86 400 s).
+   :type omega: float, optional
+
+   :returns: Heat flux *G(z,t)* (W m⁻²).  The output follows NumPy’s
+             broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: * If *lambda_s_val*, *k_s_val*, and *t* cannot be broadcast to a
+         common shape.
+       * If any element of *k_s_val* or *omega* is non-positive.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – All inputs are internally converted to
+     :class:`numpy.ndarray`; the formula is evaluated element-wise and
+     fully supports broadcasting.
+   * **Units** – Ensure consistent SI units: W m⁻¹ K⁻¹ (λ_s),
+     m² s⁻¹ (k_s), s (t), and rad s⁻¹ (ω).
+   * **Scope** – The solution presumes purely sinusoidal boundary
+     forcing and homogeneous soil properties; real-world deviations
+     (e.g., non-sine forcing, stratified soils, moisture variation)
+     will introduce error.
+
+   .. rubric:: References
+
+   Gao, Z., Horton, R., Luo, L., & Kucharik, C. J. (2010).
+   *A simple method to measure soil temperature dynamics: Theory and
+   application.* **Soil Science Society of America Journal**, 74(2),
+   580-588. https://doi.org/10.2136/sssaj2009.0169
+
+   .. rubric:: Examples
+
+   >>> # Daily cycle at 5 cm depth
+   >>> AT      = 8.0                           # K
+   >>> lambda_ = 1.2                           # W m-1 K-1
+   >>> kappa   = 1.0e-6                        # m2 s-1
+   >>> t_day   = np.linspace(0, 86400, 97)     # 15-min steps
+   >>> Gz      = gao2010_gz(AT, lambda_, kappa, t_day)
+   >>> Gz.shape
+   (97,)
 
 
-.. py:function:: heusinkveld_gz(A_n, Phi_n, n_max, k_s_val, lambda_s_val, w)
+.. py:function:: heusinkveld_gz(A_n: numpy.ndarray | float, Phi_n: numpy.ndarray | float, n_max: int, k_s_val: numpy.ndarray | float, lambda_s_val: numpy.ndarray | float, w: float) -> numpy.ndarray | float
 
-   H04 harmonic solution (Eq. 4).
+   Compute *soil heat flux* :math:`G(z,t)` from the **H04 harmonic
+   series solution** proposed by Heusinkveld et al. (2004, Eq. 4).
+
+   The approach represents the surface (ground) temperature as a Fourier
+   series with harmonics up to order *n_max*.  For each harmonic
+   :math:`n` the heat-flux contribution at depth *z* can be written
+
+   .. math::
+
+       G_n(z,t) \;=\;
+       \frac{\lambda_s}{10\,\pi}\,
+       A_n\;
+       \sqrt{\frac{1}{k_s\,n\,\omega\,k_s}}\;
+       \sin\bigl(n\,\omega\,t + \Phi_n + \tfrac{\pi}{4}\bigr),
+
+   and the full signal is obtained by summing over *n = 1…n_max*.
+
+   **Note** The implementation below follows the algebraic form that
+   appeared in H04; consult the original paper for derivation details
+   and recommended parameter ranges.
+
+   :param A_n: Amplitudes :math:`A_n` of the *n*-th harmonic of surface-temperature
+               forcing (K).  Provide either
+               * a single scalar applied to every harmonic, or
+               * an array of length ≥ *n_max* giving amplitude for each harmonic.
+   :type A_n: float or array_like
+   :param Phi_n: Phase shifts :math:`\Phi_n` (rad) corresponding to each harmonic
+                 order.  Same broadcasting rules as *A_n*.
+   :type Phi_n: float or array_like
+   :param n_max: Highest harmonic order to include in the summation.
+   :type n_max: int
+   :param k_s_val: Soil thermal diffusivity :math:`k_s` (m² s⁻¹).
+   :type k_s_val: float or array_like
+   :param lambda_s_val: Soil thermal conductivity :math:`\lambda_s` (W m⁻¹ K⁻¹).
+   :type lambda_s_val: float or array_like
+   :param w: Fundamental angular frequency :math:`\omega` (rad s⁻¹), e.g.
+             :math:`2\pi/86400` for a 24-h cycle.
+   :type w: float
+
+   :returns: Soil heat flux *G(z,t)* (W m⁻²).  The return shape is the
+             broadcast shape of the input arrays (excluding the harmonic axis).
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If *n_max* is less than 1, or if *k_s_val* or *w* are non-positive,
+       or if the amplitudes/phases cannot be broadcast to length
+       *n_max*.
+
+   .. rubric:: Notes
+
+   * **Vectorization** – Internally, the harmonic index axis has length
+     *n_max* (``n = np.arange(1, n_max+1)``).  All other dimensions come
+     from broadcasting *A_n*, *Phi_n*, *k_s_val*, *lambda_s_val*, and
+     *t* (if vectorized in the caller).
+   * **Units** – Consistency with SI units is assumed.
+   * **Interpretation** – The prefactor ``λ_s / (10 π)`` appears in
+     H04’s original derivation.  If you adopt a different convention
+     (e.g., depth-explicit damping), modify accordingly.
+
+   .. rubric:: References
+
+   Heusinkveld, B. G., Jacobs, A. F. G., Holtslag, A. A. M., & *et al.*
+   (2004). *Surface energy balance closure in an arid region: The role
+   of soil heat flux.* Agricultural and Forest Meteorology, **122**(1),
+   21-37. https://doi.org/10.1016/j.agrformet.2003.09.005
+
+   .. rubric:: Examples
+
+   >>> # Daily cycle with three harmonics
+   >>> A = np.array([10, 4, 1.5])          # K
+   >>> Phi = np.array([0, -np.pi/6, np.pi/8])
+   >>> Gz = heusinkveld_gz(A, Phi, n_max=3,
+   ...                     k_s_val=1e-6,
+   ...                     lambda_s_val=1.0,
+   ...                     w=2*np.pi/86400)
+   >>> Gz.shape
+   ()
 
 
-.. py:function:: hsieh2009_gz(tz_series, time_series, cv_series, ks_series)
+.. py:function:: hsieh2009_gz(tz_series: numpy.ndarray | list | tuple, time_series: numpy.ndarray | list | tuple, cv_series: numpy.ndarray | list | tuple, ks_series: numpy.ndarray | list | tuple) -> float
 
-   Half‑order integral solution (Eq. 5).
+   Compute **soil heat flux** at the end of a temperature record
+   using the *half-order integral* (Hsieh et al., 2009, Eq. 5).
 
-   tz_series, cv_series, ks_series must be monotonically increasing in *time_series*.
+   The method exploits the analytical solution of the one-dimensional
+   heat-conduction equation for a semi-infinite medium, leading to a
+   convolution integral of order ½ that relates the time series of
+   near-surface soil temperature to the downward heat flux:
+
+   .. math::
+
+       G(t_N) \;=\;
+       2\sqrt{\frac{k_s(t_N)\,C_v(t_N)}{\pi}}\;
+       \int_{t_0}^{t_N}
+           \frac{\partial T(z,t')}{\partial t'}
+           \left(t_N - t'\right)^{-1/2}\,dt'
+
+   In discrete form with linear interpolation between measurements
+   :math:`t_i \;(i = 0,\dots,N)`,
+
+   .. math::
+
+       \int_{t_0}^{t_N}\!
+           \frac{dT}{dt'}\,(t_N-t')^{-1/2}dt'
+       \approx
+       \sum_{i=0}^{N-1}
+         \frac{\Delta T_i}{\Delta t_i}\!
+         \left[(t_N-t_i)^{1/2} - (t_N-t_{i+1})^{1/2}\right],
+
+   where :math:`\Delta T_i = T_{i+1}-T_i` and
+   :math:`\Delta t_i = t_{i+1}-t_i`.
+
+   The final scalar result corresponds to the flux at
+   :math:`t_N\;(=\text{time_series}[-1])`.
+
+   :param tz_series: Near-surface (or shallow-depth) soil temperature observations
+                     *T(z,t)* (K).  Length **N ≥ 2**.
+   :type tz_series: array_like
+   :param time_series: Strictly monotonically increasing time stamps (s) matching
+                       `tz_series`.  Same length **N**.
+   :type time_series: array_like
+   :param cv_series: Volumetric heat capacity *C_v* (J m⁻³ K⁻¹) at each
+                     time stamp.  Same length **N**.
+   :type cv_series: array_like
+   :param ks_series: Thermal diffusivity *k_s* (m² s⁻¹) at each time stamp.
+                     Same length **N**.
+   :type ks_series: array_like
+
+   :returns: Soil heat flux *G(t_N)* at the final time point (W m⁻²).
+   :rtype: float
+
+   :raises ValueError: * If the four series differ in length or have fewer than two
+         samples.
+       * If `time_series` is not strictly increasing.
+       * If any element of `cv_series` or `ks_series` is non-positive.
+
+   .. rubric:: Notes
+
+   * The algorithm uses a forward finite-difference for
+     :math:`dT/dt'` and trapezoidal integration over each interval
+     *[t_i, t_{i+1}]*.
+   * Only the latest values of *k_s* and *C_v* are used, consistent
+     with the Hsieh et al. derivation.  Replace with a time-variable
+     kernel if property changes are large over the record.
+   * All inputs are cast to :class:`numpy.ndarray` with
+     ``dtype=float``.
+
+   .. rubric:: References
+
+   Hsieh, C.-I., Katul, G., & Chi, T.-C. (2009).
+   *Retrieval of soil heat flux from soil temperature data by the
+   continuous-time heat equation model.*
+   **Water Resources Research**, 45, W08433.
+   https://doi.org/10.1029/2009WR007891
+
+   .. rubric:: Examples
+
+   >>> times  = np.array([0, 600, 1200, 1800])        # every 10 min
+   >>> temps  = np.array([292.5, 293.0, 293.6, 294.0])  # K
+   >>> Cv     = np.full_like(temps, 2.3e6)            # J m-3 K-1
+   >>> ks     = np.full_like(temps, 1.1e-6)           # m2 s-1
+   >>> hsieh2009_gz(temps, times, Cv, ks)
+   -2.13...
 
 
-.. py:function:: leuning_damping_depth(z, zr, AT_z, AT_zr)
+.. py:function:: leuning_damping_depth(z: numpy.ndarray | float, zr: numpy.ndarray | float, AT_z: numpy.ndarray | float, AT_zr: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Compute damping depth *d* via Eq. (6).
+   Estimate the **thermal damping depth** *d* (m) from the exponential
+   decay of temperature–wave amplitude with depth.
+
+   The formulation is based on Eq. (6) of Leuning *et al.* (1985) for a
+   one-dimensional, sinusoidally forced soil column:
+
+   .. math::
+
+       d \;=\;
+       \frac{z_r - z}{\ln\bigl(A_T(z) / A_T(z_r)\bigr)}
+
+   where
+
+   * :math:`A_T(z)` — amplitude of the temperature wave at depth *z*
+   * :math:`z_r`  — reference depth (m)
+   * :math:`A_T(z_r)` — amplitude at reference depth
+
+   The equation assumes amplitudes decrease monotonically with depth
+   following :math:`A_T(z) = A_T(0)\,\exp(-z/d)`.
+
+   :param z: Depth(s) (m) at which the amplitude *A_T(z)* was measured.
+             Positive values denote depth below the surface.
+   :type z: float or array_like
+   :param zr: Reference depth(s) *z_r* (m).  Must be broadcast-compatible with
+              *z*.  If *zr* < *z* the denominator switches sign, yielding a
+              negative *d* that should be interpreted carefully.
+   :type zr: float or array_like
+   :param AT_z: Temperature-wave amplitude at *z* (K).
+   :type AT_z: float or array_like
+   :param AT_zr: Temperature-wave amplitude at *z_r* (K).
+   :type AT_zr: float or array_like
+
+   :returns: Thermal damping depth *d* (m).  The output shape follows NumPy
+             broadcasting rules applied to the four inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any of the following conditions occur:
+
+       * *AT_z* or *AT_zr* contain non-positive values (log undefined).
+       * *AT_z* and *AT_zr* are equal everywhere, leading to
+         ``ln(1) = 0`` and division by zero.
+       * The inputs cannot be broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Vectorisation** — Internally, all inputs are converted to
+     :class:`~numpy.ndarray`; the formula is applied element-wise and
+     fully supports broadcasting.
+   * **Physical meaning** — Larger *d* indicates slower attenuation of
+     temperature fluctuations with depth (i.e. higher thermal
+     diffusivity or conductivity).  Very small logarithmic denominators
+     (`AT_z` ≈ `AT_zr`) imply an extremely deep damping depth that may
+     fall outside the soil column considered.
+   * **Units** — Depths must share the same units (metres).  Amplitudes
+     may be in kelvins or degrees Celsius provided they use identical
+     scaling.
+
+   .. rubric:: References
+
+   Leuning, R., Barlow, E. W. R., & Paltridge, G. (1985).
+   *Temperature gradients in a soil: Theory and measurement.*
+   *Agricultural and Forest Meteorology*, 35(1–4), 127–143.
+   https://doi.org/10.1016/0168-1923(85)90067-3
+
+   .. rubric:: Examples
+
+   >>> d = leuning_damping_depth(z=0.10, zr=0.05, AT_z=4.0, AT_zr=8.0)
+   >>> round(d, 4)
+   0.0721
+
+   >>> #Broadcasting with arrays
+   >>> depths = np.array([0.05, 0.10, 0.20])
+   >>> amps   = np.array([8.0, 4.0, 1.5])
+   >>> d_arr  = leuning_damping_depth(depths, 0.02, amps, 10.0)
+   >>> d_arr
+   array([0.0380..., 0.0495..., 0.0854...])
 
 
-.. py:function:: leuning_gz(g_zr, z, zr, d)
+.. py:function:: leuning_gz(g_zr: numpy.ndarray | float, z: numpy.ndarray | float, zr: numpy.ndarray | float, d: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Exponentially adjust G_z from reference depth (Eq. 7).
+   Extrapolate **soil heat flux** from a reference depth *z_r* to a
+   shallower (or deeper) target depth *z* using an *exponential
+   attenuation* model (Leuning *et al.* 1985, Eq. 7).
+
+   The model assumes the amplitude of the heat-flux wave decays
+   exponentially with depth at the same *damping depth* **d** that
+   governs temperature attenuation:
+
+   .. math::
+
+       G(z,t) \;=\; G(z_r,t)\;\exp\!\left(\frac{z_r - z}{d}\right)
+
+   where
+   :math:`G(z_r,t)` is the measured flux at *z_r* (W m⁻²).
+
+   :param g_zr: Heat flux measured at reference depth *z_r* (W m⁻²).  Can be a
+                scalar or a NumPy-broadcastable array (e.g. a time series).
+   :type g_zr: float or array_like
+   :param z: Target depth *z* (m, **positive downward**).  Must be broadcast-
+             compatible with *g_zr*.
+   :type z: float or array_like
+   :param zr: Reference depth *z_r* (m, positive downward).  Broadcast
+              compatible with *z*.
+   :type zr: float or array_like
+   :param d: Thermal damping depth (m).  Positive; same shape rules as *z*.
+   :type d: float or array_like
+
+   :returns: Estimated heat flux at depth *z* (W m⁻²).  Follows NumPy
+             broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *d* is non-positive, or if inputs cannot be
+       broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Direction of extrapolation** –
+     *z < z_r* (shallower) ⇒ magnitude *increases* toward the surface;
+     *z > z_r* (deeper)   ⇒ magnitude *decreases* with depth.
+   * **Vectorisation** – Inputs are converted to
+     :class:`numpy.ndarray` and the formula is evaluated element-wise.
+   * **Limitations** – The simple exponential form ignores soil
+     layering and moisture variability; best suited to homogeneous
+     profiles over the depth interval considered.
+
+   .. rubric:: References
+
+   Leuning, R., Barlow, E. W. R., & Paltridge, G. (1985).
+   *Temperature gradients in a soil: Theory and measurement.*
+   **Agricultural and Forest Meteorology**, 35(1–4), 127-143.
+   https://doi.org/10.1016/0168-1923(85)90067-3
+
+   .. rubric:: Examples
+
+   >>> # Single depth conversion
+   >>> leuning_gz(g_zr=-12.0, z=0.05, zr=0.08, d=0.07)
+   -18.841...
+
+   >>> # Vectorized daily time series
+   >>> g_plate = np.random.normal(-10, 3, 1440)      # W m-2 @ 8 cm
+   >>> d       = 0.07                                # m
+   >>> Gz_5cm  = leuning_gz(g_plate, z=0.05, zr=0.08, d=d)
+   >>> Gz_5cm.shape
+   (1440,)
 
 
-.. py:function:: simple_measurement_gz(g_zr, cv_layers, tz_layers, dt, dz_layers)
+.. py:function:: simple_measurement_gz(g_zr: numpy.ndarray | float, cv_layers: numpy.ndarray | float, tz_layers: numpy.ndarray | float, dt: float, dz_layers: numpy.ndarray | float) -> numpy.ndarray | float
 
-   Simple‑measurement variant of calorimetric method (Eq. 8).
+       Ground-heat-flux estimate at a target depth *z* using the
+       **simple-measurement variant** of the *calorimetric* method
+       (Liebethal & Foken 2007, Eq. 8).
+
+       The algorithm corrects a heat-flux‐plate measurement taken at a
+       reference depth *z_r* by adding an approximation of the heat storage
+       change *ΔS* in the soil slab between the plate and the surface,
+       computed from two successive soil-temperature profiles:
+
+       .. math::
+
+           G(z,t_j) \;=\; G(z_r,t_j)
+           \;+\; \sum_{l=1}^{N} C_{v,l}\,\Delta z_l\,
+
+   rac{\Delta T_{l,j} +
+   rac{1}{2}igl(\Delta T_{l,j} - \Delta T_{l,j-1}igr)}
+                       {\Delta t}
+
+       where
+
+       * :math:`C_{v,l}` — volumetric heat capacity of layer *l*
+         (J m⁻³ K⁻¹)
+       * :math:`\Delta z_l` — layer thickness (m)
+       * :math:`\Delta T_{l,j}` — temperature change in layer *l*
+         between *t_{j-1}* and *t_j* (K)
+       * :math:`\Delta t` — measurement interval (s)
+
+       The centred finite-difference term in brackets approximates the
+       mid-interval temperature tendency, providing second-order accuracy
+       from simple time-series measurements (`tz_layers`).
+
+       Parameters
+       ----------
+       g_zr : float or array_like
+           Plate-measured soil heat flux at reference depth *z_r*
+           (W m⁻²).  Length **M** time steps.
+       cv_layers : array_like
+           Volumetric heat capacity for each of *N* soil layers
+           (J m⁻³ K⁻¹).  Shape ``(N,)`` or broadcast-compatible with the
+           first axis of `tz_layers`.
+       tz_layers : array_like
+           Layer-average soil temperatures.  Shape ``(N, M)`` where *N* is
+           the number of layers (matching `cv_layers`/`dz_layers`) and *M*
+           is the number of time stamps (matching `g_zr`).
+       dt : float
+           Constant time step between consecutive temperature samples
+           (s).  Must be positive.
+       dz_layers : array_like
+           Thickness of each layer (m).  Shape ``(N,)`` broadcast-compatible
+           with `cv_layers`.
+
+       Returns
+       -------
+       float or numpy.ndarray
+           Calorimetrically corrected soil heat flux at depth *z*
+           (W m⁻²).  Length **M − 1** because the centred difference
+           requires two successive profiles.
+
+       Raises
+       ------
+       ValueError
+           If input dimensions are inconsistent, `dt` ≤ 0, or any layer
+           arrays contain non-finite values.
+
+       Notes
+       -----
+       * **Temporal alignment** – The first output value corresponds to the
+         mid-point of the first two temperature samples
+         ``t[0] … t[1]``; therefore the result is shifted **½ Δt** relative
+         to the plate-flux time stamps.
+       * **Vectorisation** – All calculations are fully vectorized using
+         NumPy broadcasting.  Inputs are internally cast to
+         :class:`numpy.ndarray`.
+       * **Applicability** – Best suited to homogeneous layers with
+         high-quality temperature measurements at identical timestamps.
+
+       References
+       ----------
+       Liebethal, C., & Foken, T. (2007). *Evaluation of six parameterization
+       approaches for the ground heat flux.* Agricultural and Forest
+       Meteorology, 143(1–2), 65–80.
+       https://doi.org/10.1016/j.agrformet.2006.11.001
+
+       Examples
+       --------
+       >>> g_plate = np.array([-12.3, -10.9, -8.5])      # W m-2 at z_r
+       >>> Cv       = np.array([2.3e6, 2.1e6])           # two layers
+       >>> T        = np.array([[15.0, 15.5, 16.0],      # °C layer 1
+       ...                     [14.0, 14.2, 14.4]])      # °C layer 2
+       >>> dz       = np.array([0.03, 0.02])             # m
+       >>> Gz = simple_measurement_gz(g_plate, Cv, T, dt=1800, dz_layers=dz)
+       >>> Gz
+       array([-10.700...,  -8.317...])
 
 
-.. py:function:: wbz12_g_gz(g_zr_series, time_series, z, zr, k_s_val)
 
-   WBZ12‑G method (Eq. 9–10).
+.. py:function:: wbz12_g_gz(g_zr_series: numpy.ndarray | list | tuple, time_series: numpy.ndarray | list | tuple, z: float, zr: float, k_s_val: float) -> numpy.ndarray
+
+   Estimate **soil heat flux** at a shallow depth *z* from a flux-plate
+   record at reference depth *z_r* using the **WBZ12-G convolution
+   method** (Wang, Bou-Zeid & Zhang 2012, their Eq. 9–10).
+
+   The algorithm inverts the one-dimensional heat-conduction equation
+   for a semi-infinite homogeneous soil, assuming a step-response
+   kernel based on the complementary error function *erfc*:
+
+   .. math::
+
+       G(z,t) \;=\; 2\,G(z_r,t)
+       \;-\; \frac{J(t)}{\Delta F_z(t)}
+
+   with the discrete convolution integral
+
+   .. math::
+
+       J(t_n) \;=\;
+       \sum_{j=0}^{n-1}
+       \tfrac{\bigl[G(z_r,t_{n-j-1}) + G(z_r,t_{n-j})\bigr]}{2}\;
+       \Delta F_z(t_{j+1})
+
+   and the *transfer function increment*
+
+   .. math::
+
+       \Delta F_z(t) =
+       \operatorname{erfc}\!
+       \left[\frac{z_r - z}{2\sqrt{k_s (t - t_0)}}\right]
+       \;-\;
+       \operatorname{erfc}\!
+       \left[\frac{z_r - z}{2\sqrt{k_s (t - t_0 - \Delta t)}}\right].
+
+   :param g_zr_series: Time series of heat-flux-plate measurements at *z_r* (W m⁻²);
+                       length **N**.
+   :type g_zr_series: array_like
+   :param time_series: Monotonically increasing time stamps (s) corresponding to
+                       `g_zr_series`.  Must be the same length **N**.
+   :type time_series: array_like
+   :param z: Target depth (m, **positive downward**).
+   :type z: float
+   :param zr: Reference depth of the heat-flux plate (m, positive downward).
+   :type zr: float
+   :param k_s_val: Soil thermal diffusivity *k_s* (m² s⁻¹).  Must be positive.
+   :type k_s_val: float
+
+   :returns: Estimated heat-flux series at depth *z*, same length **N** as the
+             input series (W m⁻²).
+   :rtype: numpy.ndarray
+
+   :raises ValueError: If `k_s_val ≤ 0`, the two series differ in length, time stamps
+       are non-monotonic, or contain fewer than two samples.
+
+   .. rubric:: Notes
+
+   * The first element of the output corresponds to *t₀* (no storage
+     correction possible yet); subsequent points incorporate the
+     convolution up to that instant.
+   * A very small term ``+ 1e-12`` is added under the square root to
+     avoid division by zero at *t = t₀*.
+   * The complementary error function is evaluated with
+     :func:`numpy.erfc`, which is vectorized and avoids the SciPy
+     dependency.
+
+   .. rubric:: References
+
+   Wang, W., Bou-Zeid, E., & Zhang, Y. (2012).
+   *Estimating surface heat fluxes using the surface renewal method*.
+   **Boundary-Layer Meteorology**, 144(2), 407-422.
+   https://doi.org/10.1007/s10546-012-9730-9
+
+   .. rubric:: Examples
+
+   >>> # 10-min sampled day-long plate record at zr = 0.08 m
+   >>> t  = np.arange(0, 24*3600 + 1, 600)            # s
+   >>> Gp = -10 + 5*np.sin(2*np.pi*t/86400)
+   >>> Gz = wbz12_g_gz(Gp, t, z=0.05, zr=0.08, k_s_val=1.0e-6)
+   >>> Gz.shape
+   (145,)
 
 
-.. py:function:: wbz12_s_gz(Ag, ks_val, zr, z, t, eps, omega=OMEGA_DAY)
+.. py:function:: wbz12_s_gz(Ag: numpy.ndarray | float, ks_val: numpy.ndarray | float, zr: float, z: float, t: numpy.ndarray | float, eps: numpy.ndarray | float, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   WBZ12‑S solution (Eq. 11).
+       **WBZ12-S analytic–numeric solution** for soil heat flux *G(z, t)* at
+       depth *z* (Wang, Bou-Zeid & Zhang 2012, Eq. 11).
 
-   Numerical integration is performed for the second term.
+       WBZ12-S combines a closed-form *forcing* term (sinusoidal surface
+       temperature) with a *storage* term that is expressed as a Fourier‐
+       Laplace integral and must be evaluated numerically.  The governing
+       equation assumes homogeneous soil properties and a sinusoidal
+       surface temperature of amplitude *A_g* and phase `eps`:
+
+       .. math::
+
+           G(z,t) \;=\;
+           A_g\,e^{-\eta}\,\sin\bigl(\omega t +
+   arepsilon - \eta\bigr)
+           \;-\;
+           \frac{2 A_g k_s}{\pi}
+           \int_{0}^{\infty}
+               \frac{
+                   k_s \zeta^{2} igl[\sin\varepsilon
+                   - \omega \cos\varepsilon\bigr]
+                 }{
+                   \omega^{2}
+                   + k_{s}^{2} \zeta^{4}
+               }
+               \sin\bigl[\zeta\,(z_r - z)\bigr]\,
+               e^{-k_s \zeta^{2} t}\,d\zeta
+
+       with
+
+       .. math::
+           \eta \;=\; (z_r - z)\,\sqrt{\omega / (2 k_s)}.
+
+       The first term (prefactor × sin_term) represents the periodic
+       *steady-state* component, while the integral accounts for the
+       *transient* adjustment of the soil profile.
+
+       Parameters
+       ----------
+       Ag : float or array_like
+           Amplitude of the sinusoidal surface/ground temperature (K).  Can
+           be broadcast with `t` and `eps`.
+       ks_val : float or array_like
+           Soil thermal diffusivity :math:`k_s` (m² s⁻¹).  Must be positive.
+       zr : float
+           Reference depth of the heat-flux plate (m, positive downward).
+       z : float
+           Target depth for the output heat flux (m, positive downward).
+       t : float or array_like
+           Time (s) since the start of the forcing cycle.  Broadcast-
+           compatible with `Ag` and `eps`.
+       eps : float or array_like
+           Phase shift :math:`\varepsilon` (rad) of the surface
+           temperature.  Broadcast-compatible with `t`.
+       omega : float, optional
+           Angular frequency :math:`\omega` (rad s⁻¹) of the sinusoidal
+           forcing (default is :pydata:`OMEGA_DAY` ≈ 7.272 × 10⁻⁵ s⁻¹).
+
+       Returns
+       -------
+       float or numpy.ndarray
+           Soil heat flux *G(z, t)* (W m⁻²).  The shape matches NumPy
+           broadcasting over (`Ag`, `ks_val`, `t`, `eps`).
+
+       Raises
+       ------
+       ValueError
+           If *ks_val* or *omega* are non-positive, or if the inputs cannot
+           be broadcast to a common shape.
+
+       Notes
+       -----
+       * **Numerical integral** – The transient term is evaluated using
+         :func:`scipy.integrate.quad` over :math:`\zeta \in [0, \infty)`.
+         The integral can be expensive for long time-series; cache results
+         or vectorise with more sophisticated quadrature if performance is
+         critical.
+       * **Vectorisation** – `quad` is called individually for every
+         element in the broadcasted inputs; large arrays may thus incur
+         heavy computational cost.
+       * **Units** – Use consistent SI units: W m⁻² (output), K (Ag),
+         m² s⁻¹ (ks_val), rad s⁻¹ (omega), seconds (t), metres (depths).
+
+       References
+       ----------
+       Wang, W., Bou-Zeid, E., & Zhang, Y. (2012).
+       *Estimating surface heat fluxes using the surface renewal method.*
+       **Boundary-Layer Meteorology**, 144(2), 407–422.
+       https://doi.org/10.1007/s10546-012-9730-9
+
+       Examples
+       --------
+       >>> # Daily sinusoid, single point
+       >>> G = wbz12_s_gz(
+       ...     Ag=8.0, ks_val=1.0e-6,
+       ...     zr=0.08, z=0.05,
+       ...     t=np.linspace(0, 86400, 97),
+       ...     eps=0.0
+       ... )
+       >>> G.shape
+       (97,)
 
 
-.. py:function:: exact_temperature_gz(z, AT, t, d, omega=OMEGA_DAY, T_i=298.15)
 
-   Exact sinusoidal soil‑temperature profile (Eq. 16).
+.. py:function:: exact_temperature_gz(z: numpy.ndarray | float, AT: numpy.ndarray | float, t: numpy.ndarray | float, d: numpy.ndarray | float, omega: float = OMEGA_DAY, T_i: float = 298.15) -> numpy.ndarray | float
+
+   Compute the **exact analytical soil‐temperature profile**
+   under sinusoidal surface forcing.
+
+   A sinusoidal temperature wave propagating downward through a
+   homogeneous soil decays exponentially with depth and lags in phase.
+   The closed‐form solution at depth *z* (m) is
+
+   .. math::
+
+       T(z, t) \;=\;
+       T_i
+       \;+\;
+       A_T \,
+       e^{-z/d}\,
+       \sin\bigl(\omega t \;-\; z/d\bigr),
+
+   where
+
+   * :math:`T_i` — initial (mean) temperature of the soil column (K)
+   * :math:`A_T` — amplitude of the surface-temperature oscillation (K)
+   * :math:`d` — thermal damping depth (m)
+   * :math:`\omega` — angular frequency of the forcing (rad s⁻¹)
+   * :math:`t` — time since the start of oscillation (s)
+
+   :param z: Depth below the surface (m). Positive downward.  Can be a scalar
+             or an array broadcastable with *t* and *AT*.
+   :type z: float or array_like
+   :param AT: Amplitude *A_T* of the surface temperature wave (K).
+   :type AT: float or array_like
+   :param t: Time variable (s).  Supports vectorisation.
+   :type t: float or array_like
+   :param d: Thermal damping depth (m). Must be positive.  Can be scalar or
+             broadcastable with *z*.
+   :type d: float or array_like
+   :param omega: Angular frequency *ω* (rad s⁻¹). Defaults to
+                 :pydata:`OMEGA_DAY` (≈ 7.272 × 10⁻⁵ s⁻¹ for 24 h).
+   :type omega: float, optional
+   :param T_i: Mean (initial) soil temperature (K).  Defaults to **298.15 K**
+               (25 °C).
+   :type T_i: float, optional
+
+   :returns: Soil temperature *T(z, t)* (same units as *T_i*).  The result
+             shape matches NumPy broadcasting over the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *d* or *omega* is non-positive, or if inputs
+       cannot be broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Phase lag** – Each e-folding depth *d* introduces a phase delay
+     of 1 radian (~57.3 °) relative to the surface signal.
+   * **Vectorisation** – All inputs are converted to
+     :class:`numpy.ndarray`; the formula is evaluated element-wise and
+     fully supports broadcasting.
+   * **Units** – Ensure consistent SI units (metres, seconds, kelvins).
+
+   .. rubric:: References
+
+   Adapted from Gao, Z., Horton, R., Luo, L., & Kucharik, C. J. (2010).
+   *A simple method to measure soil temperature dynamics: Theory and
+   application.* **Soil Science Society of America Journal**, 74(2),
+   580-588. https://doi.org/10.2136/sssaj2009.0169
+
+   .. rubric:: Examples
+
+   >>> # Daily cycle at 10 cm depth
+   >>> z      = 0.10                            # m
+   >>> AT     = 8.0                             # K
+   >>> d      = 0.12                            # m
+   >>> t_day  = np.linspace(0, 86400, 97)       # 15-min resolution
+   >>> Tz     = exact_temperature_gz(z, AT, t_day, d)
+   >>> Tz.shape
+   (97,)
 
 
-.. py:function:: exact_gz(z, AT, lambda_s_val, d, t, omega=OMEGA_DAY)
+.. py:function:: exact_gz(z: numpy.ndarray | float, AT: numpy.ndarray | float, lambda_s_val: numpy.ndarray | float, d: numpy.ndarray | float, t: numpy.ndarray | float, omega: float = OMEGA_DAY) -> numpy.ndarray | float
 
-   Exact sinusoidal soil‑heat‑flux (Eq. 17).
+   Exact analytical **soil-heat-flux** solution for sinusoidal surface forcing.
+
+   A sinusoidal surface–temperature wave of amplitude *A_T* and angular
+   frequency *ω* generates a heat-flux wave that decays exponentially
+   with depth and lags the temperature signal by *π / 4* radians
+   (Gao et al., 2010, Eq. 17):
+
+   .. math::
+
+       G(z,t) \;=\;
+       \sqrt{2}\;
+       \frac{\lambda_s A_T}{d}\;
+       e^{-z/d}\;
+       \sin\bigl(\omega t - z/d + \tfrac{\pi}{4}\bigr)
+
+   where
+
+   * :math:`\lambda_s` — soil thermal conductivity (W m⁻¹ K⁻¹)
+   * :math:`d` — thermal damping depth (m)
+   * :math:`z` — depth below the surface (m, positive downward)
+   * :math:`t` — time (s) since the start of oscillation
+   * :math:`\omega` — angular frequency (rad s⁻¹)
+
+   :param z: Depth(s) below the surface (m), positive downward.
+   :type z: float or array_like
+   :param AT: Amplitude *A_T* of the surface-temperature oscillation (K).
+   :type AT: float or array_like
+   :param lambda_s_val: Soil thermal conductivity *λ_s* (W m⁻¹ K⁻¹).
+   :type lambda_s_val: float or array_like
+   :param d: Thermal damping depth (m). Must be positive.
+   :type d: float or array_like
+   :param t: Time variable (s).
+   :type t: float or array_like
+   :param omega: Angular frequency *ω* (rad s⁻¹). Defaults to
+                 :pydata:`OMEGA_DAY` (≈ 7.272 × 10⁻⁵ s⁻¹, i.e. 2π / 86 400 s).
+   :type omega: float, optional
+
+   :returns: Soil heat flux *G(z, t)* (W m⁻²).  The return shape follows NumPy
+             broadcasting rules applied to the inputs.
+   :rtype: float or numpy.ndarray
+
+   :raises ValueError: If any element of *d* or *omega* is non-positive, or if inputs
+       cannot be broadcast to a common shape.
+
+   .. rubric:: Notes
+
+   * **Phase shift** – At any given depth, the heat-flux wave lags the
+     temperature wave by 45 ° (π / 4 rad).
+   * **Vectorisation** – All inputs are converted to
+     :class:`numpy.ndarray`; the expression is evaluated element-wise
+     and fully supports broadcasting.
+   * **Units** – Ensure all quantities use consistent SI units.
+
+   .. rubric:: References
+
+   Gao, Z., Horton, R., Luo, L., & Kucharik, C. J. (2010).
+   *A simple method to measure soil temperature dynamics: Theory and
+   application.* **Soil Science Society of America Journal**, 74(2),
+   580–588. https://doi.org/10.2136/sssaj2009.0169
+
+   .. rubric:: Examples
+
+   >>> # Scalar example
+   >>> exact_gz(
+   ...     z=0.05,
+   ...     AT=8.0,
+   ...     lambda_s_val=1.2,
+   ...     d=0.12,
+   ...     t=3600,
+   ... )
+   21.52...
+
+   >>> # Vectorized daily cycle
+   >>> t_day = np.linspace(0, 86400, 97)           # 15-min resolution
+   >>> Gz = exact_gz(
+   ...     z=0.10,
+   ...     AT=6.0,
+   ...     lambda_s_val=1.1,
+   ...     d=0.11,
+   ...     t=t_day,
+   ... )
+   >>> Gz.shape
+   (97,)
 
 
 .. py:function:: reference_ground_heat_flux(temp_profile: numpy.ndarray, depths: Sequence[float], times: Sequence[float], cv: float, thermal_conductivity: float, gradient_depth: float = 0.2) -> numpy.ndarray
 
-   Compute the reference ground‑heat flux *G₀,M* (Eq. 1).
+   Compute the reference ground‑heat flux *G₀,M* using the
+   gradient method combined with calorimetry for heat storage
+   (Liebethal & Foken 2006, Eq. 1).
 
-   Equation
-   --------
-   G₀,M(t) = -λ ∂T/∂z |_(z=0.2 m) + ∫_{z=0}^{0.2 m} c_v ∂T/∂t dz
+   The method combines the conductive heat flux at a reference depth
+   with the rate of change of heat stored in the soil layer above that
+   depth.
 
-   :param temp_profile: Soil temperatures (°C or K) at the depths specified by *depths* and
-                        time stamps *times*.
-   :type temp_profile: ndarray, shape (n_z, n_t)
-   :param depths: Measurement depths (m, **positive downward**).
-   :type depths: sequence of float, length *n_z*
-   :param times: Epoch time in **seconds** (may be monotonic pandas DatetimeIndex
-                 converted via ``astype('int64')/1e9``).
-   :type times: sequence of float, length *n_t*
-   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
+   .. math::
+
+       G_{0,M}(t) = -\lambda \frac{\partial T}{\partial z} \bigg|_{z=0.2m}
+                    + \int_{z=0}^{0.2m} c_v \frac{\partial T}{\partial t} dz
+
+   :param temp_profile: A 2D array of soil temperatures (°C or K) with shape
+                        `(n_depths, n_times)`.
+   :type temp_profile: numpy.ndarray
+   :param depths: A sequence of measurement depths in meters (positive downward),
+                  corresponding to the rows of `temp_profile`.
+   :type depths: Sequence[float]
+   :param times: A sequence of time stamps in seconds (e.g., Unix timestamps),
+                 corresponding to the columns of `temp_profile`.
+   :type times: Sequence[float]
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹). Assumed
+              to be constant with depth.
    :type cv: float
-   :param thermal_conductivity: Soil thermal conductivity λ (W m⁻¹ K⁻¹).
+   :param thermal_conductivity: Soil thermal conductivity λ (W m⁻¹ K⁻¹). Assumed to be
+                                constant with depth.
    :type thermal_conductivity: float
-   :param gradient_depth: Depth (m) at which the vertical gradient term is evaluated.
-   :type gradient_depth: float, default 0.20
+   :param gradient_depth: The depth (m) at which the vertical temperature gradient is
+                          evaluated, by default 0.20 m.
+   :type gradient_depth: float, optional
 
-   :returns: Instantaneous ground‑heat flux *G₀,M* (W m⁻²). Positive = downward.
-   :rtype: ndarray, shape (n_t,)
+   :returns: A 1D array of the instantaneous ground‑heat flux *G₀,M* (W m⁻²)
+             at the surface for each time step. Positive values indicate
+             downward flux.
+   :rtype: numpy.ndarray
+
+   :raises ValueError: If `temp_profile` shape does not match the lengths of `depths`
+       and `times`.
 
 
 .. py:function:: ground_heat_flux_pr(qs: numpy.ndarray, p: float) -> numpy.ndarray
 
-   Ground heat flux using a fixed *p* fraction of net radiation (Eq. 2).
+   Estimate ground heat flux as a fixed fraction of net radiation
+   (Liebethal & Foken 2006, Eq. 2).
 
-   G₀,PR(t) = ‑p · Q*ₛ(t)
+   This is a simple empirical relationship where the ground heat flux
+   is assumed to be a constant proportion of the net radiation at the
+   surface.
 
-   :param qs: Net radiation time series (W m⁻²). Positive = downward.
-   :type qs: ndarray
-   :param p: Fraction of net radiation that becomes ground‑heat flux (0–1).
+   .. math:: G_{0,PR}(t) = -p \cdot Q^*_s(t)
+
+   :param qs: Time series of net radiation (W m⁻²). Positive values are
+              typically downward.
+   :type qs: numpy.ndarray
+   :param p: The fraction of net radiation that is partitioned into
+             ground heat flux (dimensionless, typically 0 < p < 1).
    :type p: float
 
-   :returns: G₀,PR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,PR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: ground_heat_flux_lr(qs: numpy.ndarray, a: float, b: float, lag_steps: int = 0) -> numpy.ndarray
 
-   Linear net‑radiation parameterisation (Eq. 3).
+   Estimate ground heat flux using a linear regression against net
+   radiation, with an optional time lag (Liebethal & Foken 2006, Eq. 3).
 
-   G₀,LR(t) = a·Q*ₛ(t+Δt_G) + b
+   .. math:: G_{0,LR}(t) = a \cdot Q^*_s(t + \Delta t_G) + b
 
-   :param qs: Net radiation (W m⁻²).
-   :type qs: ndarray
-   :param a: Regression coefficients.
+   :param qs: Time series of net radiation (W m⁻²).
+   :type qs: numpy.ndarray
+   :param a: The slope of the linear regression (dimensionless).
    :type a: float
-   :param b: Regression coefficients.
+   :param b: The intercept of the linear regression (W m⁻²).
    :type b: float
-   :param lag_steps: Integer lag (number of samples) by which *qs* is advanced.
-   :type lag_steps: int, default 0
+   :param lag_steps: The integer time lag (number of array elements) to apply to the
+                     net radiation series. A positive value advances the series
+                     (e.g., `qs[t+lag]` is used for `G[t]`), by default 0.
+   :type lag_steps: int, optional
 
-   :returns: G₀,LR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,LR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: ur_coefficients(delta_ts: float | numpy.ndarray) -> Tuple[numpy.ndarray, numpy.ndarray]
 
-   Compute universal‑function parameters *A* and *B* (Eq. 5 & 6).
+   Compute the parameters A and B for the universal net-radiation
+   parameterization, based on the diurnal surface temperature amplitude
+   (Liebethal & Foken 2006, Eq. 5 & 6).
 
-   :param delta_ts: Diurnal amplitude of *surface* temperature (K).
-   :type delta_ts: float or ndarray
+   .. math::
+       A = 0.0074 \cdot \Delta T_s + 0.088
+       B = 1729 \cdot \Delta T_s + 65013
 
-   :returns: * **A** (*ndarray*)
-             * **B** (*ndarray (seconds)*)
+   :param delta_ts: The diurnal amplitude of the surface temperature (K or °C).
+   :type delta_ts: float or numpy.ndarray
+
+   :returns: A tuple containing the computed parameters (A, B).
+             - A is dimensionless.
+             - B is in seconds.
+   :rtype: Tuple[numpy.ndarray, numpy.ndarray]
 
 
 .. py:function:: ground_heat_flux_ur(qs: numpy.ndarray, times_sec: numpy.ndarray, delta_ts: float) -> numpy.ndarray
 
-   Universal net‑radiation parameterisation (Eq. 4).
+   Estimate ground heat flux using the universal net-radiation
+   parameterization by Santanello & Friedl (2003), as cited in
+   Liebethal & Foken (2006, Eq. 4).
 
-   Implements Santanello & Friedl (2003):
-       G₀,UR(t) = -A · cos[2π (t + 10800) / B] · Q*ₛ(t)
+   This method modulates the fraction of net radiation partitioned to
+   ground heat flux with a cosine function of the time of day.
 
-   *t* is **seconds since solar noon** (positive in afternoon).
+   .. math::
+       G_{0,UR}(t) = -A \cdot \cos\left(\frac{2\pi (t + 10800)}{B}\right)
+                     \cdot Q^*_s(t)
 
-   :param qs: Net radiation (W m⁻²).
-   :type qs: ndarray
-   :param times_sec: Seconds relative to solar noon (s).
-   :type times_sec: ndarray
-   :param delta_ts: Diurnal surface‑temperature amplitude (K).
+   :param qs: Time series of net radiation (W m⁻²).
+   :type qs: numpy.ndarray
+   :param times_sec: Time stamps in **seconds relative to solar noon**. Positive values
+                     indicate the afternoon.
+   :type times_sec: numpy.ndarray
+   :param delta_ts: The diurnal amplitude of the surface temperature (K or °C).
    :type delta_ts: float
 
-   :returns: G₀,UR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,UR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: surface_temp_amplitude(delta_t1: float, delta_t2: float, z1: float, z2: float) -> float
 
-   Compute diurnal surface‑temperature amplitude ΔT_s (Eq. 8).
+   Estimate the diurnal surface-temperature amplitude (ΔT_s) from
+   temperature amplitudes measured at two different soil depths
+   (Liebethal & Foken 2006, Eq. 8).
 
-   :param delta_t1: Diurnal temperature amplitudes (K) measured at depths *z1* and *z2*.
+   This method assumes an exponential decay of the temperature wave
+   amplitude with depth.
+
+   .. math::
+       \Delta T_s = \Delta T_1 + \Delta T_2 \cdot
+                     \exp\left(\frac{z_2}{z_2 - z_1}\right)
+
+   :param delta_t1: Diurnal temperature amplitude (K or °C) measured at depth `z1`.
    :type delta_t1: float
-   :param delta_t2: Diurnal temperature amplitudes (K) measured at depths *z1* and *z2*.
+   :param delta_t2: Diurnal temperature amplitude (K or °C) measured at depth `z2`.
    :type delta_t2: float
-   :param z1: Depths in meters (**positive downward**, with z2 > z1 > 0).
+   :param z1: The shallower depth in meters (positive downward).
    :type z1: float
-   :param z2: Depths in meters (**positive downward**, with z2 > z1 > 0).
+   :param z2: The deeper depth in meters (positive downward).
    :type z2: float
 
-   :returns: Estimated ΔT_s (K).
+   :returns: The estimated diurnal surface-temperature amplitude ΔT_s (K or °C).
    :rtype: float
+
+   :raises ValueError: If `z2` is not greater than `z1`.
 
 
 .. py:function:: phi_from_soil_moisture(theta_0_10: float, a_phi: float = 9.62, b_phi: float = 0.402) -> float
 
-   Soil‑moisture dependent φ (Eq. 10).
+   Calculate the empirical parameter φ based on soil moisture content
+   (Liebethal & Foken 2006, Eq. 10).
+
+   .. math:: \phi = a_\phi \cdot \theta_{0-10} + b_\phi
+
+   :param theta_0_10: Average volumetric soil moisture content in the top 10 cm
+                      (m³ m⁻³).
+   :type theta_0_10: float
+   :param a_phi: Empirical coefficient, by default 9.62.
+   :type a_phi: float, optional
+   :param b_phi: Empirical coefficient, by default 0.402.
+   :type b_phi: float, optional
+
+   :returns: The dimensionless parameter φ.
+   :rtype: float
 
 
 .. py:function:: ground_heat_flux_sh(h: numpy.ndarray, phase_g0: Sequence[float], phase_h: Sequence[float], u_mean: float, phi: float, omega: float = 2 * np.pi / 86400.0) -> numpy.ndarray
 
-   Ground‑heat flux from sensible heat flux H (Eq. 9).
+   Estimate ground heat flux from the sensible heat flux (H)
+   (Liebethal & Foken 2006, Eq. 9).
 
-   :param h: Sensible heat flux time series (W m⁻²).
-   :type h: ndarray
-   :param phase_g0: Phase lags φ(G₀) and φ(H) in **radians**.
-   :type phase_g0: sequence of float
-   :param phase_h: Phase lags φ(G₀) and φ(H) in **radians**.
-   :type phase_h: sequence of float
-   :param u_mean: Mean horizontal wind speed during daytime (m s⁻¹).
+   This method relates the ground heat flux to the sensible heat flux
+   through a phase-shifted and scaled relationship.
+
+   .. math::
+       G_{0,SH}(t) = -\frac{\phi}{\sqrt{\bar{u}}}
+                     \frac{\cos(\omega t + \varphi(G_0))}
+                          {\cos(\omega t + \varphi(H))} H(t)
+
+   :param h: Time series of sensible heat flux (W m⁻²).
+   :type h: numpy.ndarray
+   :param phase_g0: Phase lags of the ground heat flux, φ(G₀), in **radians**. Must
+                    have the same length as `h`.
+   :type phase_g0: Sequence[float]
+   :param phase_h: Phase lags of the sensible heat flux, φ(H), in **radians**. Must
+                   have the same length as `h`.
+   :type phase_h: Sequence[float]
+   :param u_mean: Mean horizontal wind speed during the daytime (m s⁻¹).
    :type u_mean: float
-   :param phi: Empirical parameter (dimensionless), see `phi_from_soil_moisture`.
+   :param phi: An empirical dimensionless parameter, often derived from soil
+               moisture via `phi_from_soil_moisture`.
    :type phi: float
-   :param omega: Diurnal angular frequency (s⁻¹).
-   :type omega: float, default 2π/86400
+   :param omega: The diurnal angular frequency (rad s⁻¹), by default `2π/86400`.
+   :type omega: float, optional
 
-   :returns: G₀,SH (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,SH* (W m⁻²).
+   :rtype: numpy.ndarray
+
+   :raises ValueError: If the length of phase arrays does not match the length of `h`.
 
 
 .. py:function:: ground_heat_flux_sm(gp: numpy.ndarray, t1: numpy.ndarray, delta_t: numpy.ndarray, cv: float, zp: float, dt_seconds: float) -> numpy.ndarray
 
-   Simple‑measurement parameterisation (Eq. 11).
+   Estimate surface ground heat flux using the "simple measurement"
+   parameterization, correcting a heat flux plate measurement with a
+   storage term (Liebethal & Foken 2006, Eq. 11).
 
-   :param gp: Heat‑flux plate measurement at depth *zp* (W m⁻²).
-   :type gp: ndarray
-   :param t1: Soil temperature at 0.01 m depth (K or °C).
-   :type t1: ndarray
-   :param delta_t: Temperature difference T(0.01 m) – T(z_p) (K).
-   :type delta_t: ndarray
-   :param cv: Volumetric heat capacity (J m⁻³ K⁻¹).
+   .. math::
+       G_{0,SM}(t) = G_p(t) + c_v z_p \left( \frac{dT_1}{dt} +
+                     \frac{1}{2} \frac{d(\Delta T)}{dt} \right)
+
+   :param gp: Heat flux plate measurements at depth `zp` (W m⁻²).
+   :type gp: numpy.ndarray
+   :param t1: Soil temperature at 0.01 m depth (K or °C).
+   :type t1: numpy.ndarray
+   :param delta_t: Temperature difference T(0.01 m) - T(zp) (K).
+   :type delta_t: numpy.ndarray
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
    :type cv: float
-   :param zp: Plate depth (m, positive downward).
+   :param zp: Depth of the heat flux plate (m, positive downward).
    :type zp: float
-   :param dt_seconds: Time step between consecutive samples (s).
+   :param dt_seconds: The constant time step between consecutive samples (s).
    :type dt_seconds: float
 
-   :returns: G₀,SM (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,SM* (W m⁻²).
+             The first element will be NaN due to the backward difference.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: active_layer_thickness(lambda_: float, cv: float, omega: float = 2 * np.pi / 86400) -> float
 
-   Thickness δz of the active soil layer (Eq. 13).
+   Calculate the thickness of the active soil layer (δz) for the
+   force-restore method (Liebethal & Foken 2006, Eq. 13).
+
+   .. math:: \delta_z = \sqrt{\frac{\lambda}{2 c_v \omega}}
+
+   :param lambda_: Soil thermal conductivity (W m⁻¹ K⁻¹).
+   :type lambda_: float
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
+   :type cv: float
+   :param omega: The diurnal angular frequency (rad s⁻¹), by default `2π/86400`.
+   :type omega: float, optional
+
+   :returns: The thickness of the active soil layer δz (m).
+   :rtype: float
 
 
 .. py:function:: ground_heat_flux_fr(tg: numpy.ndarray, tg_avg: float, cv: float, lambda_: float, delta_z: float | None = None, times: numpy.ndarray | None = None) -> numpy.ndarray
 
-   Force‑restore ground‑heat flux (Eq. 12).
+   Estimate ground heat flux using the two-layer force-restore method
+   (Liebethal & Foken 2006, Eq. 12).
 
-   Implements the two‑layer force‑restore formulation with an optional
-   diagnostic *δz* computed via Eq. 13 if not supplied.
+   .. math::
+       G_{0,FR}(t) = -\delta_z c_v \frac{dT_g}{dt} +
+                     \sqrt{\lambda \omega c_v} \left(
+                     \frac{1}{\omega}\frac{dT_g}{dt} + (T_g - \bar{T_g})
+                     \right)
 
-   :param tg: Temperature of the upper (surface) layer Tg(t).
-   :type tg: ndarray
-   :param tg_avg: Long‑term average or restoring temperature Tḡ (K).
+   :param tg: Time series of the upper (surface) layer temperature, Tg(t) (K).
+   :type tg: numpy.ndarray
+   :param tg_avg: The long-term average or "restoring" temperature, T̄g (K).
    :type tg_avg: float
-   :param cv: Volumetric heat capacity (J m⁻³ K⁻¹).
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
    :type cv: float
-   :param lambda_: Soil thermal conductivity λ (W m⁻¹ K⁻¹).
+   :param lambda_: Soil thermal conductivity λ (W m⁻¹ K⁻¹).
    :type lambda_: float
-   :param delta_z: Thickness of the active soil layer δz (m).  If *None*, computed
-                   from ``active_layer_thickness``.
+   :param delta_z: Thickness of the active soil layer δz (m). If `None`, it is
+                   calculated internally using `active_layer_thickness`,
+                   by default None.
    :type delta_z: float, optional
-   :param times: Time stamps in seconds.  Required when *delta_z* is None or when
-                 irregular sampling; defaults to `np.arange(len(tg))` seconds.
-   :type times: ndarray, optional
+   :param times: Time stamps in seconds corresponding to `tg`. Required for
+                 calculating the time derivative. If `None`, assumes a uniform
+                 time step of 1 second, by default None.
+   :type times: numpy.ndarray, optional
 
-   :returns: G₀,FR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,FR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: energy_balance_residual(Rn: float | numpy.ndarray, H: float | numpy.ndarray, LE: float | numpy.ndarray, G0: float | numpy.ndarray) -> float | numpy.ndarray
@@ -1684,7 +3110,7 @@ Package Contents
      returns 0.0.
    * **Vectorisation** – For vector or array input use
      :func:`numpy.vectorize` or wrap the function in
-     :pyfunc:`numpy.frompyfunc`; the core implementation is scalar for
+     :func:`numpy.frompyfunc`; the core implementation is scalar for
      numerical clarity.
    * **Usage** – ``g_z(t)`` can be convolved with an arbitrary surface
      heat-flux time series ``q₀(t)`` to obtain temperature at depth
@@ -1845,7 +3271,7 @@ Package Contents
        A : float
            Amplitude of the sinusoidal **surface heat flux** (W m⁻², positive
            downward).  Consistent with
-           :pyfunc:`sinusoidal_boundary_flux`.
+           :func:`sinusoidal_boundary_flux`.
        omega : float
            Angular frequency of the forcing (rad s⁻¹).
            For a diurnal wave ``omega = 2 * π / 86_400``.
@@ -1982,7 +3408,7 @@ Package Contents
          ``len(t) × 2000``.
        * **Coupling with temperature** –
          The companion function
-         :pyfunc:`soil_temperature_sinusoidal` gives *T(z,t)* under the
+         :func:`soil_temperature_sinusoidal` gives *T(z,t)* under the
          same boundary forcing; *G* and *T* satisfy Fourier’s law
          ``G = -k ∂T/∂z`` once thermal conductivity *k* is specified.
 
@@ -2039,103 +3465,670 @@ Package Contents
 
    Compute heat flux *G* at cell interfaces using Fourier’s law.
 
-   :param Tz: Temperature at layer **centres** (K).
+   This function calculates the conductive heat flux between soil layers
+   based on the temperature gradient and thermal conductivity.
+
+   .. math:: G = -\lambda_s \frac{\partial T}{\partial z}
+
+   :param Tz: A 1D array of temperatures at the **centre** of each soil layer (K).
    :type Tz: ArrayLike
-   :param dz: Thickness of each layer (m).
+   :param dz: A 1D array of the thickness of each soil layer (m).
    :type dz: ArrayLike
-   :param lambda_s: Thermal conductivity for each layer (W m‑1 K‑1).
+   :param lambda_s: Thermal conductivity for each layer (W m⁻¹ K⁻¹). Can be a single
+                    value (for homogeneous soil) or an array matching `Tz`.
    :type lambda_s: ArrayLike or float
 
-   :returns: Heat flux at *interfaces* (positive downward) with shape ``len(Tz)+1``.
-   :rtype: np.ndarray
+   :returns: An array of heat fluxes (W m⁻²) at the *interfaces* between layers,
+             including the surface and bottom boundaries. The length of the
+             output is `len(Tz) + 1`. Positive values indicate downward flux.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: integrated_soil_heat_flux(rho_c: ArrayLike, T_before: ArrayLike, T_after: ArrayLike, dz: ArrayLike, dt: float, G_ref: float = 0.0) -> numpy.ndarray
 
-   Discrete integration of Eq. (3)/(5) to obtain heat‑flux profile.
+   Calculate the soil heat flux profile by integrating the change in
+   heat storage upwards from a reference depth (Yang & Wang 2008, Eq. 5).
 
-   :param rho_c: Volumetric heat capacity ``ρ_s c_s`` for each layer (J m‑3 K‑1).
+   .. math::
+       G(z_i) = G(z_{ref}) + \int_{z_i}^{z_{ref}} \rho_s c_s
+                \frac{\partial T}{\partial t} dz
+
+   :param rho_c: A 1D array of volumetric heat capacity (`ρ_s c_s`) for each soil
+                 layer (J m⁻³ K⁻¹).
    :type rho_c: ArrayLike
-   :param T_before: Temperatures at two successive timesteps (K).
+   :param T_before: A 1D array of temperatures at the start of the time step (K).
    :type T_before: ArrayLike
-   :param T_after: Temperatures at two successive timesteps (K).
+   :param T_after: A 1D array of temperatures at the end of the time step (K).
    :type T_after: ArrayLike
-   :param dz: Layer thicknesses (m).
+   :param dz: A 1D array of layer thicknesses (m).
    :type dz: ArrayLike
-   :param dt: Timestep (s).
+   :param dt: The duration of the time step (s).
    :type dt: float
-   :param G_ref: Heat flux at the lower reference depth *z_ref* (W m‑2).  Often ≈ 0.
-   :type G_ref: float, default 0
+   :param G_ref: The heat flux at the lower reference depth `z_ref` (W m⁻²). This
+                 is typically assumed to be zero at a sufficient depth, by default 0.0.
+   :type G_ref: float, optional
 
-   :returns: Heat flux at the *upper* interface of every layer, size ``len(dz)``.
-   :rtype: np.ndarray
+   :returns: An array of heat fluxes (W m⁻²) at the *upper interface* of each
+             layer, with a size of `len(dz)`.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: volumetric_heat_capacity(theta: ArrayLike, theta_sat: float | ArrayLike) -> numpy.ndarray
 
-   Volumetric heat capacity of moist soil.
+   Calculate the volumetric heat capacity of moist soil based on its
+   water content (Yang & Wang 2008, Eq. 4).
 
-   :param theta: Volumetric water content (m³ m‑3).
+   .. math::
+       \rho_s c_s = (1 - \theta_{sat}) \rho_{d}c_{d} + \theta \rho_w c_w
+
+   :param theta: Volumetric water content (m³ m⁻³).
    :type theta: ArrayLike
-   :param theta_sat: Soil porosity.
+   :param theta_sat: Soil porosity, i.e., saturated volumetric water content (m³ m⁻³).
    :type theta_sat: float or ArrayLike
 
-   :returns: ``ρ_s c_s`` (J m‑3 K‑1).
-   :rtype: np.ndarray
+   :returns: The volumetric heat capacity `ρ_s c_s` (J m⁻³ K⁻¹).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: stretched_grid(n: int, D: float, xi: float) -> numpy.ndarray
 
-   Generate *n* layer thicknesses following the exponential stretching rule.
+   Generate layer thicknesses for a vertically stretched grid.
 
-   :param n: Number of layers.
+   The grid layer thickness increases exponentially with depth, allowing
+   for higher resolution near the surface.
+
+   .. math:: \Delta z_i = \Delta z_0 \exp(\xi (i-1))
+
+   :param n: The number of soil layers.
    :type n: int
-   :param D: Total domain depth (m).
+   :param D: The total depth of the soil domain (m).
    :type D: float
-   :param xi: Stretching parameter; 0 → uniform grid.
+   :param xi: The stretching parameter. `xi = 0` results in a uniform grid.
+              `xi > 0` results in a grid that is finer at the top.
    :type xi: float
 
-   :returns: Thickness ``Δz_i`` for each layer *i* (m).
-   :rtype: np.ndarray
+   :returns: A 1D array of thickness `Δz_i` for each of the `n` layers (m).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: solve_tde(T_prev: ArrayLike, dz: ArrayLike, rho_c: ArrayLike, lambda_s: ArrayLike | float, Tsfc: float, Tbot: float, dt: float) -> numpy.ndarray
 
-   Implicit Crank‑Nicholson (θ = 1) solve of Eq. (7).
+   Solve the 1D thermal diffusion equation for one time step using an
+   implicit Crank-Nicolson scheme (Yang & Wang 2008, Eq. 7).
 
-   Boundary conditions (Eq. 7a, 7c) are Dirichlet.
+   This function sets up and solves the tridiagonal system of linear
+   equations `M * T_new = D` to find the temperature profile at the
+   next time step.
+
+   :param T_prev: Temperature profile at the previous time step (K).
+   :type T_prev: ArrayLike
+   :param dz: Layer thicknesses (m).
+   :type dz: ArrayLike
+   :param rho_c: Volumetric heat capacity of each layer (J m⁻³ K⁻¹).
+   :type rho_c: ArrayLike
+   :param lambda_s: Thermal conductivity of each layer (W m⁻¹ K⁻¹).
+   :type lambda_s: ArrayLike or float
+   :param Tsfc: Surface temperature boundary condition (K).
+   :type Tsfc: float
+   :param Tbot: Bottom temperature boundary condition (K).
+   :type Tbot: float
+   :param dt: Time step (s).
+   :type dt: float
+
+   :returns: The new temperature profile at `t + dt`, including boundary nodes.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: correct_profile(T_model: ArrayLike, depths_model: ArrayLike, T_obs: ArrayLike, depths_obs: ArrayLike) -> numpy.ndarray
 
-   Add linear‑interpolated bias (Eq. ΔT_k) to model profile.
+   Correct a modeled temperature profile using observed temperatures.
+
+   This function calculates the bias (error) between the model and
+   observations at the observation depths, then linearly interpolates
+   this bias across the entire model grid to correct the profile.
+
+   :param T_model: The modeled temperature profile (K).
+   :type T_model: ArrayLike
+   :param depths_model: The depths corresponding to `T_model` (m).
+   :type depths_model: ArrayLike
+   :param T_obs: The observed temperatures (K).
+   :type T_obs: ArrayLike
+   :param depths_obs: The depths of the observations (m).
+   :type depths_obs: ArrayLike
+
+   :returns: The corrected temperature profile.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: surface_temperature_longwave(R_lw_up: float, R_lw_dn: float, emissivity: float = 0.98) -> float
 
-   Convert upward/downward long‑wave radiation to surface temperature (Eq. 8).
+   Calculate surface temperature from upward and downward long-wave
+   radiation measurements using the Stefan-Boltzmann law (Yang & Wang 2008, Eq. 8).
+
+   .. math::
+       T_s = \left[ \frac{R_{lw}^{\uparrow} - (1 - \epsilon) R_{lw}^{\downarrow}}
+                     {\epsilon \sigma} \right]^{1/4}
+
+   :param R_lw_up: Upwelling long-wave radiation (W m⁻²).
+   :type R_lw_up: float
+   :param R_lw_dn: Downwelling long-wave radiation (W m⁻²).
+   :type R_lw_dn: float
+   :param emissivity: Surface emissivity (dimensionless), by default 0.98.
+   :type emissivity: float, optional
+
+   :returns: The calculated surface temperature (K).
+   :rtype: float
 
 
 .. py:function:: thermal_conductivity_yang2008(theta: ArrayLike, theta_sat: float, rho_dry: float | ArrayLike) -> numpy.ndarray
 
-   Estimate soil thermal conductivity following Yang et al. (2005) (Eq. 9).
+   Estimate soil thermal conductivity based on soil moisture and dry
+   density, following Yang et al. (2005) as cited in
+   Yang & Wang (2008, Eq. 9).
+
+   :param theta: Volumetric water content (m³ m⁻³).
+   :type theta: ArrayLike
+   :param theta_sat: Saturated volumetric water content (porosity) (m³ m⁻³).
+   :type theta_sat: float
+   :param rho_dry: Dry soil bulk density (kg m⁻³).
+   :type rho_dry: float or ArrayLike
+
+   :returns: The estimated soil thermal conductivity `λ_s` (W m⁻¹ K⁻¹).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: flux_error_linear(rho_c: ArrayLike, S2_minus_S1: ArrayLike, dt: float) -> numpy.ndarray
 
-   Error introduced when using a LINEAR temperature profile (diagnostic).
+   Calculate the diagnostic error in heat flux that arises from assuming
+   a linear temperature profile between measurement points
+   (Yang & Wang 2008, Eq. 11).
+
+   .. math:: \Delta G_i = \frac{\rho_s c_s (S_{i,2} - S_{i,1})}{\Delta t}
+
+   :param rho_c: Volumetric heat capacity for each layer (J m⁻³ K⁻¹).
+   :type rho_c: ArrayLike
+   :param S2_minus_S1: The area difference representing the deviation from linearity.
+   :type S2_minus_S1: ArrayLike
+   :param dt: The time step (s).
+   :type dt: float
+
+   :returns: The flux error for each layer (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: surface_energy_residual(R_net: float, H: float, LE: float, G0: float) -> float
 
-   Return the residual *ΔE* in Eq. (12).
+   Calculate the residual of the surface energy budget (Yang & Wang 2008, Eq. 12).
+
+   .. math:: \Delta E = R_{net} - (H + LE + G_0)
+
+   :param R_net: Net radiation (W m⁻²).
+   :type R_net: float
+   :param H: Sensible heat flux (W m⁻²).
+   :type H: float
+   :param LE: Latent heat flux (W m⁻²).
+   :type LE: float
+   :param G0: Surface ground heat flux (W m⁻²).
+   :type G0: float
+
+   :returns: The energy balance residual `ΔE` (W m⁻²).
+   :rtype: float
 
 
 .. py:function:: tdec_step(T_prev: ArrayLike, dz: ArrayLike, theta: ArrayLike, theta_sat: float, rho_dry: float, lambda_const: float, Tsfc: float, Tbot: float, dt: float, depths_model: ArrayLike, T_obs: ArrayLike, depths_obs: ArrayLike) -> Tuple[numpy.ndarray, numpy.ndarray]
 
-   One integration step of the TDEC scheme.
+   Perform a single integration step of the TDEC (Temperature Diffusion
+   Error Correction) scheme.
 
-   :returns: * **T_corr** (*np.ndarray*) -- Corrected temperature profile at *t + dt*.
-             * **G_prof** (*np.ndarray*) -- Heat‑flux profile (W m‑2) at layer interfaces.
+   This function encapsulates the predict-correct sequence for one time step.
+
+   :param T_prev: Temperature profile from the previous time step (K).
+   :type T_prev: ArrayLike
+   :param dz: Layer thicknesses (m).
+   :type dz: ArrayLike
+   :param theta: Volumetric water content profile (m³ m⁻³).
+   :type theta: ArrayLike
+   :param theta_sat: Soil porosity (m³ m⁻³).
+   :type theta_sat: float
+   :param rho_dry: Dry soil bulk density (kg m⁻³).
+   :type rho_dry: float
+   :param lambda_const: A constant thermal conductivity for the prediction step (W m⁻¹ K⁻¹).
+   :type lambda_const: float
+   :param Tsfc: Surface temperature boundary condition (K).
+   :type Tsfc: float
+   :param Tbot: Bottom temperature boundary condition (K).
+   :type Tbot: float
+   :param dt: Time step (s).
+   :type dt: float
+   :param depths_model: Depths of the model grid nodes (m).
+   :type depths_model: ArrayLike
+   :param T_obs: Observed temperatures for the correction step (K).
+   :type T_obs: ArrayLike
+   :param depths_obs: Depths of the observed temperatures (m).
+   :type depths_obs: ArrayLike
+
+   :returns: A tuple containing:
+             - `T_corr`: The corrected temperature profile at `t + dt`.
+             - `G_prof`: The corresponding heat flux profile (W m⁻²) at layer interfaces.
+   :rtype: Tuple[np.ndarray, np.ndarray]
+
+
+.. py:data:: DEFAULT_CS
+   :value: 2.1
+
+
+.. py:data:: LATENT_HEAT_INV
+   :value: 0.408
+
+
+.. py:function:: soil_heat_flux_general(t_current: Union[float, numpy.typing.ArrayLike], t_previous: Union[float, numpy.typing.ArrayLike], delta_t: float, delta_z: float = 1.0, c_s: float = DEFAULT_CS) -> Union[float, numpy.ndarray]
+
+   Soil heat flux from the general calorimetric equation (FAO-56 Eq. 41).
+
+   .. math::
+       G = c_s \, \frac{T_i - T_{i-1}}{\Delta t} \, \Delta z
+
+   :param t_current: Mean air temperature of the current period [°C].
+   :type t_current: float or array_like
+   :param t_previous: Mean air temperature of the previous period [°C].
+   :type t_previous: float or array_like
+   :param delta_t: Length of the time interval in **days**.  For successive months use
+                   ~30.4; for a single month pair use the actual number of days between
+                   the midpoints of the two months.
+   :type delta_t: float
+   :param delta_z: Effective soil depth [m].  Typical values are 0.10–0.20 m for daily
+                   periods and 0.5–2.0 m for monthly periods.  Default is 1.0 m
+                   (standard for successive-month calculations).
+   :type delta_z: float, optional
+   :param c_s: Soil heat capacity [MJ m⁻³ °C⁻¹].  Default ``2.1``.
+   :type c_s: float, optional
+
+   :returns: Soil heat flux *G* [MJ m⁻² day⁻¹].  Positive values indicate heat
+             transfer into the soil (warming); negative values indicate heat
+             release from the soil (cooling).
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   This is the most general form.  Equations 43 and 44 are simplified
+   versions derived from this equation by assuming c_s = 2.1 MJ/(m³·°C),
+   Δz = 1.0 m, and Δt appropriate for monthly intervals (~30 days).
+
+   For Eq. 43:  0.07 ≈ 2.1 × 1.0 / (2 × 30)
+   For Eq. 44:  0.14 ≈ 2.1 × 1.0 / (1 × 30)  (÷ by half the interval)
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — March to April:
+
+   >>> soil_heat_flux_general(16.1, 14.1, delta_t=30.0, delta_z=1.0)
+   0.14
+
+
+.. py:function:: soil_heat_flux_daily() -> float
+
+   Daily soil heat flux for a grass reference surface (FAO-56 Eq. 42).
+
+   For a daily time step, soil heat flux beneath a grass reference surface
+   is small relative to net radiation and may be assumed to be zero.
+
+   :returns: ``0.0`` [MJ m⁻² day⁻¹].
+   :rtype: float
+
+   .. rubric:: Notes
+
+   This assumption holds for a dense, grass-covered surface where the soil
+   surface temperature cycle nearly cancels over 24 hours.  For bare soil
+   or sparse vegetation, daily *G* can be significant and should be
+   estimated by other means (e.g., the general equation or measured data).
+
+
+.. py:function:: soil_heat_flux_monthly(t_month_prev: Union[float, numpy.typing.ArrayLike], t_month_next: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Monthly soil heat flux using adjacent months (FAO-56 Eq. 43).
+
+   When both the previous and next month's mean air temperatures are
+   available, this is the preferred monthly estimate.
+
+   .. math::
+       G_{\text{month},i} = 0.07 \, (T_{i+1} - T_{i-1})
+
+   :param t_month_prev: Mean air temperature of the **previous** month [°C].
+   :type t_month_prev: float or array_like
+   :param t_month_next: Mean air temperature of the **next** month [°C].
+   :type t_month_next: float or array_like
+
+   :returns: Monthly soil heat flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   The coefficient 0.07 derives from Eq. 41 with c_s = 2.1 MJ/(m³·°C),
+   Δz = 1.0 m, and a two-month span (Δt ≈ 2 × 30 = 60 days):
+
+       2.1 × 1.0 / 60 = 0.035  →  rounded/adopted as 0.07 in FAO-56.
+
+   (The FAO text notes that the coefficient accounts for the relationship
+   between air and soil temperature damping; it is empirically calibrated
+   for a grass reference surface.)
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — April soil heat flux (March = 14.1 °C, May = 18.8 °C):
+
+   >>> soil_heat_flux_monthly(14.1, 18.8)
+   0.329
+
+
+.. py:function:: soil_heat_flux_monthly_prev_only(t_month_prev: Union[float, numpy.typing.ArrayLike], t_month_cur: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Monthly soil heat flux — next month unavailable (FAO-56 Eq. 44).
+
+   When the next month's temperature is not yet known (e.g., real-time or
+   forecast applications), use this equation with the current and previous
+   month.
+
+   .. math::
+       G_{\text{month},i} = 0.14 \, (T_i - T_{i-1})
+
+   :param t_month_prev: Mean air temperature of the **previous** month [°C].
+   :type t_month_prev: float or array_like
+   :param t_month_cur: Mean air temperature of the **current** month [°C].
+   :type t_month_cur: float or array_like
+
+   :returns: Monthly soil heat flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   The coefficient 0.14 is exactly twice the Eq. 43 coefficient because
+   the temperature difference spans only one month instead of two:
+
+       2.1 × 1.0 / 30 ≈ 0.07 × 2 = 0.14
+
+   When both adjacent months are available, prefer ``soil_heat_flux_monthly()``
+   (Eq. 43) for greater accuracy.
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — March soil heat flux (Feb = 12.1 °C, Mar = 14.1 °C):
+
+   >>> soil_heat_flux_monthly_prev_only(12.1, 14.1)
+   0.28
+
+
+.. py:function:: soil_heat_flux_hourly(rn: Union[float, numpy.typing.ArrayLike], is_daytime: Union[bool, numpy.typing.ArrayLike], day_coeff: float = 0.1, night_coeff: float = 0.5) -> Union[float, numpy.ndarray]
+
+   Hourly (sub-daily) soil heat flux as a fraction of net radiation.
+
+   Based on the ASCE Standardized Reference Evapotranspiration Equation
+   (ASCE-EWRI, 2005), which recommends estimating *G* for hourly or
+   shorter periods as a proportion of net radiation *Rn*:
+
+   .. math::
+       G_{\text{day}}   &= 0.1 \; R_n   \quad \text{(daytime)}
+
+       G_{\text{night}} &= 0.5 \; R_n   \quad \text{(nighttime)}
+
+   :param rn: Net radiation at the crop surface [MJ m⁻² hr⁻¹].
+   :type rn: float or array_like
+   :param is_daytime: ``True`` for daytime periods, ``False`` for nighttime.
+                      For array inputs, must be broadcastable with *rn*.
+   :type is_daytime: bool or array_like of bool
+   :param day_coeff: Fraction of Rn used for daytime G.  Default ``0.1``.
+   :type day_coeff: float, optional
+   :param night_coeff: Fraction of Rn used for nighttime G.  Default ``0.5``.
+   :type night_coeff: float, optional
+
+   :returns: Soil heat flux [MJ m⁻² hr⁻¹] (same units as *rn*).
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Notes
+
+   Daytime is typically defined as the period when *Rn* > 0.  Some
+   implementations use the solar angle or the time relative to sunrise
+   and sunset instead.
+
+   The default coefficients (0.1 / 0.5) are calibrated for a grass
+   reference surface.  For other surfaces the ratio G/Rn can vary
+   considerably (see Allen et al., 1998, Table 7-2).
+
+   .. rubric:: Examples
+
+   Daytime hour with Rn = 2.5 MJ m⁻² hr⁻¹:
+
+   >>> soil_heat_flux_hourly(2.5, is_daytime=True)
+   0.25
+
+   Nighttime hour with Rn = -0.4 MJ m⁻² hr⁻¹:
+
+   >>> soil_heat_flux_hourly(-0.4, is_daytime=False)
+   -0.2
+
+
+.. py:function:: soil_heat_flux_hourly_auto(rn: Union[float, numpy.typing.ArrayLike], day_coeff: float = 0.1, night_coeff: float = 0.5) -> Union[float, numpy.ndarray]
+
+   Hourly soil heat flux, auto-detecting day/night from Rn sign.
+
+   Convenience wrapper around :func:`soil_heat_flux_hourly` that uses
+   ``Rn > 0`` as the daytime indicator, which is the most common approach
+   in practice.
+
+   :param rn: Net radiation at the crop surface [MJ m⁻² hr⁻¹].
+   :type rn: float or array_like
+   :param day_coeff: Fraction of Rn used for daytime G.  Default ``0.1``.
+   :type day_coeff: float, optional
+   :param night_coeff: Fraction of Rn used for nighttime G.  Default ``0.5``.
+   :type night_coeff: float, optional
+
+   :returns: Soil heat flux [MJ m⁻² hr⁻¹].
+   :rtype: float or numpy.ndarray
+
+   .. rubric:: Examples
+
+   >>> soil_heat_flux_hourly_auto(2.5)
+   0.25
+   >>> soil_heat_flux_hourly_auto(-0.4)
+   -0.2
+
+
+.. py:function:: soil_heat_flux_monthly_series(t_monthly: numpy.typing.ArrayLike, method: str = 'centered') -> numpy.ndarray
+
+   Compute soil heat flux for each month in a temperature time series.
+
+   This is a convenience function that applies the appropriate FAO-56
+   monthly equation to each element of a monthly mean-temperature array.
+
+   :param t_monthly: 1-D array of consecutive monthly mean air temperatures [°C].
+                     Length *N* ≥ 2.
+   :type t_monthly: array_like
+   :param method:
+                  * ``"centered"`` (default) — Uses Eq. 43 where both neighbors
+                    exist; falls back to Eq. 44 at the boundaries (first and last
+                    month).
+                  * ``"backward"`` — Uses Eq. 44 for every month (each month
+                    compared only to the previous month).  The first element is
+                    set to ``NaN`` because there is no previous month.
+   :type method: {"centered", "backward"}, optional
+
+   :returns: Array of monthly soil heat flux values [MJ m⁻² day⁻¹], same
+             length as *t_monthly*.
+   :rtype: numpy.ndarray
+
+   .. rubric:: Examples
+
+   FAO-56 Example 13 — March, April, May temps:
+
+   >>> temps = [14.1, 16.1, 18.8]
+   >>> soil_heat_flux_monthly_series(temps, method="centered")
+   array([0.28 , 0.329, 0.378])
+
+   Using backward-only differences:
+
+   >>> soil_heat_flux_monthly_series(temps, method="backward")
+   array([  nan, 0.28 , 0.378])
+
+
+.. py:function:: soil_heat_flux_annual_cycle(t_monthly_12: numpy.typing.ArrayLike) -> numpy.ndarray
+
+   Monthly G for a complete 12-month annual cycle using Eq. 43.
+
+   Wraps around so that January uses December and February as neighbors,
+   and December uses November and January.
+
+   :param t_monthly_12: Exactly 12 monthly mean air temperatures [°C], January through
+                        December.
+   :type t_monthly_12: array_like
+
+   :returns: Shape ``(12,)`` array of monthly soil heat flux [MJ m⁻² day⁻¹].
+   :rtype: numpy.ndarray
+
+   .. rubric:: Examples
+
+   >>> temps = [5.2, 6.1, 9.3, 13.0, 17.5, 22.1,
+   ...          25.4, 24.8, 20.6, 14.9, 9.2, 5.8]
+   >>> g = soil_heat_flux_annual_cycle(temps)
+   >>> g[0]   # January: 0.07 * (Feb - Dec)
+   0.021...
+
+
+.. py:function:: energy_to_evap(energy: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert energy flux to equivalent evaporation depth (FAO-56 Eq. 20).
+
+   .. math::
+       E_{\text{equiv}} = 0.408 \times E
+
+   :param energy: Energy flux [MJ m⁻² day⁻¹] (or per hour, etc.).
+   :type energy: float or array_like
+
+   :returns: Equivalent evaporation [mm day⁻¹] (or per hour, etc.).
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: evap_to_energy(evap: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert equivalent evaporation depth back to energy flux.
+
+   Inverse of :func:`energy_to_evap`.
+
+   :param evap: Equivalent evaporation [mm day⁻¹].
+   :type evap: float or array_like
+
+   :returns: Energy flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: mj_m2_day_to_w_m2(flux: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert flux from MJ m⁻² day⁻¹ to W m⁻².
+
+   .. math::
+       W\,m^{-2} = \frac{MJ\,m^{-2}\,day^{-1}}{0.0864}
+
+   :param flux: Energy flux [MJ m⁻² day⁻¹].
+   :type flux: float or array_like
+
+   :returns: Energy flux [W m⁻²].
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: w_m2_to_mj_m2_day(flux: Union[float, numpy.typing.ArrayLike]) -> Union[float, numpy.ndarray]
+
+   Convert flux from W m⁻² to MJ m⁻² day⁻¹.
+
+   :param flux: Energy flux [W m⁻²].
+   :type flux: float or array_like
+
+   :returns: Energy flux [MJ m⁻² day⁻¹].
+   :rtype: float or numpy.ndarray
+
+
+.. py:function:: _run_tests() -> None
+
+   Reproduce FAO-56 Example 13 and other verification cases.
+
+
+.. py:function:: compute_soil_storage_integrated(df: pandas.DataFrame, col_T5: str = 'T5cm', col_VWC5: str = 'VWC5cm', col_IRT: str = None, depth: float = 0.05, bulk_density: float = 1300.0, specific_heat_dry: float = 870.0, specific_heat_water: float = 4218.0) -> pandas.Series
+
+   Calculate the soil heat storage flux (S) in W/m² using a change-in-storage
+   approach.
+
+   This function estimates the energy stored or released in the upper soil
+   layer by accounting for the heat capacity of both the dry soil minerals and
+   the stored liquid water. It supports an integrated temperature approach if
+   infrared surface temperature (IRT) is available. In the slab approach, you
+   assume the estimate at the given depth applies to the whole slab above the
+   depth, whereas the IRT approach takes the mean between surface temperature
+   and temperature at depth.
+
+   Note that this method is the same as the method use to calculate soil heat
+   storage flux in the Campbell Scientific programs, though that progrmam uses
+   higher-frequency data for the calculations.
+
+   :param df: Input dataframe with a DatetimeIndex.
+   :type df: pd.DataFrame
+   :param col_T5: Column name for soil temperature at 5cm depth [°C].
+   :type col_T5: str, default "T5cm"
+   :param col_VWC5: Column name for Volumetric Water Content at 5cm depth [m³/m³].
+   :type col_VWC5: str, default "VWC5cm"
+   :param col_IRT: Column name for surface infrared temperature [°C]. If provided,
+                   the layer temperature is the average of surface and 5cm temps. Note
+                   that this must be surface temperature, not canopy temperature
+   :type col_IRT: str, optional
+   :param depth: The thickness of the soil layer being measured [m].
+   :type depth: float, default 0.05
+   :param bulk_density: Dry bulk density of the soil [kg/m³].
+   :type bulk_density: float, default 1300.0
+   :param specific_heat_dry: Specific heat capacity of dry soil minerals [J/(kg·K)].
+   :type specific_heat_dry: float, default 870.0
+   :param specific_heat_water: Specific heat capacity of water [J/(kg·K)].
+   :type specific_heat_water: float, default 4218.0
+
+   :returns: The calculated soil heat storage flux [W/m²].
+             Positive values indicate energy moving into storage (warming).
+   :rtype: pd.Series
+
+   .. rubric:: Notes
+
+   The canopy storage flux is calculated as:
+   $$S_{canopy} = \frac{m_{veg} \cdot C_{p} \cdot \Delta T}{\Delta t}$$
+
+   Where:
+   - $m_{veg}$ = Fresh biomass ($kg/m^2$), calculated as $(height / 100) \cdot density\_factor$
+   - $C_{p}$ = Specific heat of fresh vegetation ($\approx 3900 \text{ J/kg}\cdot\text{K}$)
+   - $\Delta T$ = Change in canopy temperature between time steps
+   - $\Delta t$ = Time step in seconds
+
+
+.. py:function:: compute_canopy_storage(df: pandas.DataFrame, col_irt: str = 'T_CANOPY', crop_type: str = 'alfalfa', height_cm: str | float = None, density_factor: float = None) -> pandas.Series
+
+   Calculate the energy storage flux of a plant canopy (S_canopy) in W/m².
+
+   This function estimates heat storage within biomass. It can handle dynamic
+   vegetation growth if a height column is provided, otherwise it falls back
+   to static heights. Height and density values can be entered by the user or
+   taken from a dictionary within the function.
+
+   Care should be taken to examine the crop default values and the specific
+   heat of the vegetation.
+
+   :param df: Input dataframe with a DatetimeIndex.
+   :type df: pd.DataFrame
+   :param col_irt: Column name for the canopy surface temperature [°C].
+   :type col_irt: str, default "T_CANOPY"
+   :param crop_type: Options: 'alfalfa', 'corn', 'hay', 'wetland'. Used to determine
+                     defaults for height and density.
+   :type crop_type: str, default "alfalfa"
+   :param height_cm: If str: The column name in `df` containing canopy height [cm] over time.
+                     If float: A static height value [cm].
+                     If None: Uses default height for the specified `crop_type`.
+   :type height_cm: str or float, optional
+   :param density_factor: Biomass density [kg/m² per meter height]. If None, uses default
+                          for the specified `crop_type`.
+   :type density_factor: float, optional
+
+   :returns: Energy storage flux [W/m²].
+   :rtype: pd.Series
 
 

--- a/docs/autoapi/soil_heat/liebethal_and_folken/index.rst
+++ b/docs/autoapi/soil_heat/liebethal_and_folken/index.rst
@@ -13,7 +13,7 @@ soil_heat.liebethal_and_folken
 
    Each public function is named after the paper section and
    equation number for easy cross‑referencing.  Helper utilities
-   for finite‐difference gradients and unit handling are provided
+   for finite‑difference gradients and unit handling are provided
    at the end of the module.
 
    .. rubric:: References
@@ -47,188 +47,292 @@ Module Contents
 
 .. py:function:: reference_ground_heat_flux(temp_profile: numpy.ndarray, depths: Sequence[float], times: Sequence[float], cv: float, thermal_conductivity: float, gradient_depth: float = 0.2) -> numpy.ndarray
 
-   Compute the reference ground‑heat flux *G₀,M* (Eq. 1).
+   Compute the reference ground‑heat flux *G₀,M* using the
+   gradient method combined with calorimetry for heat storage
+   (Liebethal & Foken 2006, Eq. 1).
 
-   Equation
-   --------
-   G₀,M(t) = -λ ∂T/∂z |_(z=0.2 m) + ∫_{z=0}^{0.2 m} c_v ∂T/∂t dz
+   The method combines the conductive heat flux at a reference depth
+   with the rate of change of heat stored in the soil layer above that
+   depth.
 
-   :param temp_profile: Soil temperatures (°C or K) at the depths specified by *depths* and
-                        time stamps *times*.
-   :type temp_profile: ndarray, shape (n_z, n_t)
-   :param depths: Measurement depths (m, **positive downward**).
-   :type depths: sequence of float, length *n_z*
-   :param times: Epoch time in **seconds** (may be monotonic pandas DatetimeIndex
-                 converted via ``astype('int64')/1e9``).
-   :type times: sequence of float, length *n_t*
-   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
+   .. math::
+
+       G_{0,M}(t) = -\lambda \frac{\partial T}{\partial z} \bigg|_{z=0.2m}
+                    + \int_{z=0}^{0.2m} c_v \frac{\partial T}{\partial t} dz
+
+   :param temp_profile: A 2D array of soil temperatures (°C or K) with shape
+                        `(n_depths, n_times)`.
+   :type temp_profile: numpy.ndarray
+   :param depths: A sequence of measurement depths in meters (positive downward),
+                  corresponding to the rows of `temp_profile`.
+   :type depths: Sequence[float]
+   :param times: A sequence of time stamps in seconds (e.g., Unix timestamps),
+                 corresponding to the columns of `temp_profile`.
+   :type times: Sequence[float]
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹). Assumed
+              to be constant with depth.
    :type cv: float
-   :param thermal_conductivity: Soil thermal conductivity λ (W m⁻¹ K⁻¹).
+   :param thermal_conductivity: Soil thermal conductivity λ (W m⁻¹ K⁻¹). Assumed to be
+                                constant with depth.
    :type thermal_conductivity: float
-   :param gradient_depth: Depth (m) at which the vertical gradient term is evaluated.
-   :type gradient_depth: float, default 0.20
+   :param gradient_depth: The depth (m) at which the vertical temperature gradient is
+                          evaluated, by default 0.20 m.
+   :type gradient_depth: float, optional
 
-   :returns: Instantaneous ground‑heat flux *G₀,M* (W m⁻²). Positive = downward.
-   :rtype: ndarray, shape (n_t,)
+   :returns: A 1D array of the instantaneous ground‑heat flux *G₀,M* (W m⁻²)
+             at the surface for each time step. Positive values indicate
+             downward flux.
+   :rtype: numpy.ndarray
+
+   :raises ValueError: If `temp_profile` shape does not match the lengths of `depths`
+       and `times`.
 
 
 .. py:function:: ground_heat_flux_pr(qs: numpy.ndarray, p: float) -> numpy.ndarray
 
-   Ground heat flux using a fixed *p* fraction of net radiation (Eq. 2).
+   Estimate ground heat flux as a fixed fraction of net radiation
+   (Liebethal & Foken 2006, Eq. 2).
 
-   G₀,PR(t) = ‑p · Q*ₛ(t)
+   This is a simple empirical relationship where the ground heat flux
+   is assumed to be a constant proportion of the net radiation at the
+   surface.
 
-   :param qs: Net radiation time series (W m⁻²). Positive = downward.
-   :type qs: ndarray
-   :param p: Fraction of net radiation that becomes ground‑heat flux (0–1).
+   .. math:: G_{0,PR}(t) = -p \cdot Q^*_s(t)
+
+   :param qs: Time series of net radiation (W m⁻²). Positive values are
+              typically downward.
+   :type qs: numpy.ndarray
+   :param p: The fraction of net radiation that is partitioned into
+             ground heat flux (dimensionless, typically 0 < p < 1).
    :type p: float
 
-   :returns: G₀,PR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,PR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: ground_heat_flux_lr(qs: numpy.ndarray, a: float, b: float, lag_steps: int = 0) -> numpy.ndarray
 
-   Linear net‑radiation parameterisation (Eq. 3).
+   Estimate ground heat flux using a linear regression against net
+   radiation, with an optional time lag (Liebethal & Foken 2006, Eq. 3).
 
-   G₀,LR(t) = a·Q*ₛ(t+Δt_G) + b
+   .. math:: G_{0,LR}(t) = a \cdot Q^*_s(t + \Delta t_G) + b
 
-   :param qs: Net radiation (W m⁻²).
-   :type qs: ndarray
-   :param a: Regression coefficients.
+   :param qs: Time series of net radiation (W m⁻²).
+   :type qs: numpy.ndarray
+   :param a: The slope of the linear regression (dimensionless).
    :type a: float
-   :param b: Regression coefficients.
+   :param b: The intercept of the linear regression (W m⁻²).
    :type b: float
-   :param lag_steps: Integer lag (number of samples) by which *qs* is advanced.
-   :type lag_steps: int, default 0
+   :param lag_steps: The integer time lag (number of array elements) to apply to the
+                     net radiation series. A positive value advances the series
+                     (e.g., `qs[t+lag]` is used for `G[t]`), by default 0.
+   :type lag_steps: int, optional
 
-   :returns: G₀,LR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,LR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: ur_coefficients(delta_ts: float | numpy.ndarray) -> Tuple[numpy.ndarray, numpy.ndarray]
 
-   Compute universal‑function parameters *A* and *B* (Eq. 5 & 6).
+   Compute the parameters A and B for the universal net-radiation
+   parameterization, based on the diurnal surface temperature amplitude
+   (Liebethal & Foken 2006, Eq. 5 & 6).
 
-   :param delta_ts: Diurnal amplitude of *surface* temperature (K).
-   :type delta_ts: float or ndarray
+   .. math::
+       A = 0.0074 \cdot \Delta T_s + 0.088
+       B = 1729 \cdot \Delta T_s + 65013
 
-   :returns: * **A** (*ndarray*)
-             * **B** (*ndarray (seconds)*)
+   :param delta_ts: The diurnal amplitude of the surface temperature (K or °C).
+   :type delta_ts: float or numpy.ndarray
+
+   :returns: A tuple containing the computed parameters (A, B).
+             - A is dimensionless.
+             - B is in seconds.
+   :rtype: Tuple[numpy.ndarray, numpy.ndarray]
 
 
 .. py:function:: ground_heat_flux_ur(qs: numpy.ndarray, times_sec: numpy.ndarray, delta_ts: float) -> numpy.ndarray
 
-   Universal net‑radiation parameterisation (Eq. 4).
+   Estimate ground heat flux using the universal net-radiation
+   parameterization by Santanello & Friedl (2003), as cited in
+   Liebethal & Foken (2006, Eq. 4).
 
-   Implements Santanello & Friedl (2003):
-       G₀,UR(t) = -A · cos[2π (t + 10800) / B] · Q*ₛ(t)
+   This method modulates the fraction of net radiation partitioned to
+   ground heat flux with a cosine function of the time of day.
 
-   *t* is **seconds since solar noon** (positive in afternoon).
+   .. math::
+       G_{0,UR}(t) = -A \cdot \cos\left(\frac{2\pi (t + 10800)}{B}\right)
+                     \cdot Q^*_s(t)
 
-   :param qs: Net radiation (W m⁻²).
-   :type qs: ndarray
-   :param times_sec: Seconds relative to solar noon (s).
-   :type times_sec: ndarray
-   :param delta_ts: Diurnal surface‑temperature amplitude (K).
+   :param qs: Time series of net radiation (W m⁻²).
+   :type qs: numpy.ndarray
+   :param times_sec: Time stamps in **seconds relative to solar noon**. Positive values
+                     indicate the afternoon.
+   :type times_sec: numpy.ndarray
+   :param delta_ts: The diurnal amplitude of the surface temperature (K or °C).
    :type delta_ts: float
 
-   :returns: G₀,UR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,UR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: surface_temp_amplitude(delta_t1: float, delta_t2: float, z1: float, z2: float) -> float
 
-   Compute diurnal surface‑temperature amplitude ΔT_s (Eq. 8).
+   Estimate the diurnal surface-temperature amplitude (ΔT_s) from
+   temperature amplitudes measured at two different soil depths
+   (Liebethal & Foken 2006, Eq. 8).
 
-   :param delta_t1: Diurnal temperature amplitudes (K) measured at depths *z1* and *z2*.
+   This method assumes an exponential decay of the temperature wave
+   amplitude with depth.
+
+   .. math::
+       \Delta T_s = \Delta T_1 + \Delta T_2 \cdot
+                     \exp\left(\frac{z_2}{z_2 - z_1}\right)
+
+   :param delta_t1: Diurnal temperature amplitude (K or °C) measured at depth `z1`.
    :type delta_t1: float
-   :param delta_t2: Diurnal temperature amplitudes (K) measured at depths *z1* and *z2*.
+   :param delta_t2: Diurnal temperature amplitude (K or °C) measured at depth `z2`.
    :type delta_t2: float
-   :param z1: Depths in meters (**positive downward**, with z2 > z1 > 0).
+   :param z1: The shallower depth in meters (positive downward).
    :type z1: float
-   :param z2: Depths in meters (**positive downward**, with z2 > z1 > 0).
+   :param z2: The deeper depth in meters (positive downward).
    :type z2: float
 
-   :returns: Estimated ΔT_s (K).
+   :returns: The estimated diurnal surface-temperature amplitude ΔT_s (K or °C).
    :rtype: float
+
+   :raises ValueError: If `z2` is not greater than `z1`.
 
 
 .. py:function:: phi_from_soil_moisture(theta_0_10: float, a_phi: float = 9.62, b_phi: float = 0.402) -> float
 
-   Soil‑moisture dependent φ (Eq. 10).
+   Calculate the empirical parameter φ based on soil moisture content
+   (Liebethal & Foken 2006, Eq. 10).
+
+   .. math:: \phi = a_\phi \cdot \theta_{0-10} + b_\phi
+
+   :param theta_0_10: Average volumetric soil moisture content in the top 10 cm
+                      (m³ m⁻³).
+   :type theta_0_10: float
+   :param a_phi: Empirical coefficient, by default 9.62.
+   :type a_phi: float, optional
+   :param b_phi: Empirical coefficient, by default 0.402.
+   :type b_phi: float, optional
+
+   :returns: The dimensionless parameter φ.
+   :rtype: float
 
 
 .. py:function:: ground_heat_flux_sh(h: numpy.ndarray, phase_g0: Sequence[float], phase_h: Sequence[float], u_mean: float, phi: float, omega: float = 2 * np.pi / 86400.0) -> numpy.ndarray
 
-   Ground‑heat flux from sensible heat flux H (Eq. 9).
+   Estimate ground heat flux from the sensible heat flux (H)
+   (Liebethal & Foken 2006, Eq. 9).
 
-   :param h: Sensible heat flux time series (W m⁻²).
-   :type h: ndarray
-   :param phase_g0: Phase lags φ(G₀) and φ(H) in **radians**.
-   :type phase_g0: sequence of float
-   :param phase_h: Phase lags φ(G₀) and φ(H) in **radians**.
-   :type phase_h: sequence of float
-   :param u_mean: Mean horizontal wind speed during daytime (m s⁻¹).
+   This method relates the ground heat flux to the sensible heat flux
+   through a phase-shifted and scaled relationship.
+
+   .. math::
+       G_{0,SH}(t) = -\frac{\phi}{\sqrt{\bar{u}}}
+                     \frac{\cos(\omega t + \varphi(G_0))}
+                          {\cos(\omega t + \varphi(H))} H(t)
+
+   :param h: Time series of sensible heat flux (W m⁻²).
+   :type h: numpy.ndarray
+   :param phase_g0: Phase lags of the ground heat flux, φ(G₀), in **radians**. Must
+                    have the same length as `h`.
+   :type phase_g0: Sequence[float]
+   :param phase_h: Phase lags of the sensible heat flux, φ(H), in **radians**. Must
+                   have the same length as `h`.
+   :type phase_h: Sequence[float]
+   :param u_mean: Mean horizontal wind speed during the daytime (m s⁻¹).
    :type u_mean: float
-   :param phi: Empirical parameter (dimensionless), see `phi_from_soil_moisture`.
+   :param phi: An empirical dimensionless parameter, often derived from soil
+               moisture via `phi_from_soil_moisture`.
    :type phi: float
-   :param omega: Diurnal angular frequency (s⁻¹).
-   :type omega: float, default 2π/86400
+   :param omega: The diurnal angular frequency (rad s⁻¹), by default `2π/86400`.
+   :type omega: float, optional
 
-   :returns: G₀,SH (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,SH* (W m⁻²).
+   :rtype: numpy.ndarray
+
+   :raises ValueError: If the length of phase arrays does not match the length of `h`.
 
 
 .. py:function:: ground_heat_flux_sm(gp: numpy.ndarray, t1: numpy.ndarray, delta_t: numpy.ndarray, cv: float, zp: float, dt_seconds: float) -> numpy.ndarray
 
-   Simple‑measurement parameterisation (Eq. 11).
+   Estimate surface ground heat flux using the "simple measurement"
+   parameterization, correcting a heat flux plate measurement with a
+   storage term (Liebethal & Foken 2006, Eq. 11).
 
-   :param gp: Heat‑flux plate measurement at depth *zp* (W m⁻²).
-   :type gp: ndarray
-   :param t1: Soil temperature at 0.01 m depth (K or °C).
-   :type t1: ndarray
-   :param delta_t: Temperature difference T(0.01 m) – T(z_p) (K).
-   :type delta_t: ndarray
-   :param cv: Volumetric heat capacity (J m⁻³ K⁻¹).
+   .. math::
+       G_{0,SM}(t) = G_p(t) + c_v z_p \left( \frac{dT_1}{dt} +
+                     \frac{1}{2} \frac{d(\Delta T)}{dt} \right)
+
+   :param gp: Heat flux plate measurements at depth `zp` (W m⁻²).
+   :type gp: numpy.ndarray
+   :param t1: Soil temperature at 0.01 m depth (K or °C).
+   :type t1: numpy.ndarray
+   :param delta_t: Temperature difference T(0.01 m) - T(zp) (K).
+   :type delta_t: numpy.ndarray
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
    :type cv: float
-   :param zp: Plate depth (m, positive downward).
+   :param zp: Depth of the heat flux plate (m, positive downward).
    :type zp: float
-   :param dt_seconds: Time step between consecutive samples (s).
+   :param dt_seconds: The constant time step between consecutive samples (s).
    :type dt_seconds: float
 
-   :returns: G₀,SM (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,SM* (W m⁻²).
+             The first element will be NaN due to the backward difference.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: active_layer_thickness(lambda_: float, cv: float, omega: float = 2 * np.pi / 86400) -> float
 
-   Thickness δz of the active soil layer (Eq. 13).
+   Calculate the thickness of the active soil layer (δz) for the
+   force-restore method (Liebethal & Foken 2006, Eq. 13).
+
+   .. math:: \delta_z = \sqrt{\frac{\lambda}{2 c_v \omega}}
+
+   :param lambda_: Soil thermal conductivity (W m⁻¹ K⁻¹).
+   :type lambda_: float
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
+   :type cv: float
+   :param omega: The diurnal angular frequency (rad s⁻¹), by default `2π/86400`.
+   :type omega: float, optional
+
+   :returns: The thickness of the active soil layer δz (m).
+   :rtype: float
 
 
 .. py:function:: ground_heat_flux_fr(tg: numpy.ndarray, tg_avg: float, cv: float, lambda_: float, delta_z: float | None = None, times: numpy.ndarray | None = None) -> numpy.ndarray
 
-   Force‑restore ground‑heat flux (Eq. 12).
+   Estimate ground heat flux using the two-layer force-restore method
+   (Liebethal & Foken 2006, Eq. 12).
 
-   Implements the two‑layer force‑restore formulation with an optional
-   diagnostic *δz* computed via Eq. 13 if not supplied.
+   .. math::
+       G_{0,FR}(t) = -\delta_z c_v \frac{dT_g}{dt} +
+                     \sqrt{\lambda \omega c_v} \left(
+                     \frac{1}{\omega}\frac{dT_g}{dt} + (T_g - \bar{T_g})
+                     \right)
 
-   :param tg: Temperature of the upper (surface) layer Tg(t).
-   :type tg: ndarray
-   :param tg_avg: Long‑term average or restoring temperature Tḡ (K).
+   :param tg: Time series of the upper (surface) layer temperature, Tg(t) (K).
+   :type tg: numpy.ndarray
+   :param tg_avg: The long-term average or "restoring" temperature, T̄g (K).
    :type tg_avg: float
-   :param cv: Volumetric heat capacity (J m⁻³ K⁻¹).
+   :param cv: Volumetric heat capacity of the soil (J m⁻³ K⁻¹).
    :type cv: float
-   :param lambda_: Soil thermal conductivity λ (W m⁻¹ K⁻¹).
+   :param lambda_: Soil thermal conductivity λ (W m⁻¹ K⁻¹).
    :type lambda_: float
-   :param delta_z: Thickness of the active soil layer δz (m).  If *None*, computed
-                   from ``active_layer_thickness``.
+   :param delta_z: Thickness of the active soil layer δz (m). If `None`, it is
+                   calculated internally using `active_layer_thickness`,
+                   by default None.
    :type delta_z: float, optional
-   :param times: Time stamps in seconds.  Required when *delta_z* is None or when
-                 irregular sampling; defaults to `np.arange(len(tg))` seconds.
-   :type times: ndarray, optional
+   :param times: Time stamps in seconds corresponding to `tg`. Required for
+                 calculating the time derivative. If `None`, assumes a uniform
+                 time step of 1 second, by default None.
+   :type times: numpy.ndarray, optional
 
-   :returns: G₀,FR (W m⁻²).
-   :rtype: ndarray
+   :returns: Time series of the estimated ground heat flux *G₀,FR* (W m⁻²).
+   :rtype: numpy.ndarray
 
 

--- a/docs/autoapi/soil_heat/soil_heat/index.rst
+++ b/docs/autoapi/soil_heat/soil_heat/index.rst
@@ -35,6 +35,7 @@ Functions
    soil_heat.soil_heat.calculate_thermal_diffusivity_for_pair
    soil_heat.soil_heat.calculate_thermal_properties_for_all_pairs
    soil_heat.soil_heat.estimate_rhoc_dry
+   soil_heat.soil_heat.calculate_soil_heat_storage
 
 
 Module Contents
@@ -268,28 +269,58 @@ Module Contents
 
 .. py:function:: soil_heat_flux(T_upper, T_lower, depth_upper, depth_lower, k)
 
-   Calculate soil heat flux (G) using temperature gradient and thermal conductivity.
+   Calculate soil heat flux (G) using Fourier's law of heat conduction.
 
-   Parameters:
-   - T_upper: Temperature at upper depth (°C)
-   - T_lower: Temperature at lower depth (°C)
-   - depth_upper: Upper sensor depth (m)
-   - depth_lower: Lower sensor depth (m)
-   - k: Thermal conductivity (W/(m·°C))
+   This function computes the one-dimensional heat flux in the soil based on
+   the temperature gradient between two depths and the soil's thermal
+   conductivity. The formula used is:
 
-   Returns:
-   - Soil heat flux (W/m^2)
+   .. math::
+
+       G = -k \frac{\Delta T}{\Delta z}
+
+   where :math:`G` is the soil heat flux, :math:`k` is the thermal
+   conductivity, :math:`\Delta T` is the temperature difference, and
+   :math:`\Delta z` is the distance between the two measurement depths.
+
+   :param T_upper: Temperature at the upper depth (°C or K).
+   :type T_upper: float or array_like
+   :param T_lower: Temperature at the lower depth (°C or K).
+   :type T_lower: float or array_like
+   :param depth_upper: Depth of the upper sensor (m, positive downward).
+   :type depth_upper: float
+   :param depth_lower: Depth of the lower sensor (m, positive downward).
+   :type depth_lower: float
+   :param k: Thermal conductivity of the soil layer between the sensors (W m⁻¹ K⁻¹).
+   :type k: float or array_like
+
+   :returns: The calculated soil heat flux (W m⁻²). A positive value indicates
+             a downward flux (from the surface into the soil).
+   :rtype: float or array_like
 
 
 .. py:function:: volumetric_heat_capacity(theta_v)
 
-   Estimate volumetric heat capacity Cv (J/(m³·°C)) from soil moisture.
+   Estimate volumetric heat capacity (Cv) from soil moisture content.
 
-   Parameters:
-   - theta_v: Volumetric water content (decimal fraction, e.g., 0.20 for 20%)
+   This function uses a simple mixing model to estimate the volumetric heat
+   capacity of moist soil. It assumes the soil is a two-component mixture
+   of dry soil and water. The formula is:
 
-   Returns:
-   - Volumetric heat capacity (kJ/(m³·°C))
+   .. math::
+
+       C_v = (1 - \theta_v) C_{soil} + \theta_v C_{water}
+
+   where :math:`\theta_v` is the volumetric water content, and
+   :math:`C_{soil}` and :math:`C_{water}` are the volumetric heat
+   capacities of dry soil and water, respectively.
+
+   :param theta_v: Volumetric water content (m³ m⁻³). This is a decimal fraction,
+                   e.g., 0.20 for 20% water content.
+   :type theta_v: float or array_like
+
+   :returns: The estimated volumetric heat capacity (kJ m⁻³ K⁻¹).
+   :rtype: float or array_like
 
 
 .. py:function:: thermal_conductivity(alpha: numpy.ndarray | float, theta_v: numpy.ndarray | float) -> numpy.ndarray | float
@@ -308,7 +339,7 @@ Module Contents
    * *α* – thermal diffusivity (m² s⁻¹),
    * *C_v(θ_v)* – volumetric heat capacity (J m⁻³ K⁻¹) as a function of
      volumetric water content *θ_v* (m³ m⁻³).
-     It is obtained from :pyfunc:`volumetric_heat_capacity`.
+     It is obtained from :func:`volumetric_heat_capacity`.
 
    :param alpha: Thermal diffusivity **α** (m² s⁻¹).  May be scalar or any
                  NumPy‐broadcastable shape.
@@ -325,7 +356,7 @@ Module Contents
    .. rubric:: Notes
 
    * **Volumetric heat capacity model** –
-     :pyfunc:`volumetric_heat_capacity` typically assumes a two‐phase
+     :func:`volumetric_heat_capacity` typically assumes a two‐phase
      mixture of mineral soil and water:
 
      .. math::
@@ -686,18 +717,38 @@ Module Contents
 
 .. py:function:: thermal_diffusivity_lag(delta_t, z1, z2, period=86400)
 
-   Estimate thermal diffusivity from phase lag.
+   Estimate soil thermal diffusivity (α) from the phase lag of a temperature wave.
 
-   Parameters:
-   - delta_t: Time lag between peaks at two depths (seconds)
-   - z1, z2: Depths (m)
-   - period: Time period of wave (default = 86400 s for daily cycle)
+   This method calculates thermal diffusivity based on the time it takes for a
+   temperature wave (e.g., the diurnal cycle) to travel between two depths in
+   the soil. The formula is derived from the analytical solution to the
+   one-dimensional heat conduction equation for a periodic boundary condition:
 
-   Returns:
-   - Thermal diffusivity α (m²/s)
+   .. math::
 
-   Citation:
-   S.V. Nerpin, and A.F. Chudnovskii, Soil physics, (Moscow: Nauka) p 584, 1967 (in Russian)
+       \alpha = \frac{P (z_2 - z_1)^2}{4 \pi (\Delta t)^2}
+
+   where :math:`P` is the period of the wave, :math:`(z_2 - z_1)` is the
+   distance between the sensors, and :math:`\Delta t` is the time lag of
+   the temperature peak between the two depths.
+
+   :param delta_t: Time lag between the temperature peaks at two depths (seconds).
+   :type delta_t: float or array_like
+   :param z1: Depth of the upper sensor (m, positive downward).
+   :type z1: float
+   :param z2: Depth of the lower sensor (m, positive downward).
+   :type z2: float
+   :param period: The period of the temperature wave (seconds). The default is 86400,
+                  which corresponds to the daily (diurnal) cycle.
+   :type period: int, optional
+
+   :returns: The calculated thermal diffusivity (α) in m² s⁻¹.
+   :rtype: float or array_like
+
+   .. rubric:: References
+
+   Nerpin, S.V., and Chudnovskii, A.F. (1967). *Soil physics*.
+   (Moscow: Nauka) p 584. (In Russian)
 
 
 .. py:function:: thermal_diffusivity_logrithmic(t1z1: float, t2z1: float, t3z1: float, t4z1: float, t1z2: float, t2z2: float, t3z2: float, t4z2: float, z1: float, z2: float, period: int = 86400) -> float
@@ -807,7 +858,7 @@ Module Contents
    The function extracts the **first four consecutive samples** from two
    temperature records—one at the shallow depth ``z1`` and one at the deeper
    depth ``z2``—and passes them to
-   :pyfunc:`thermal_diffusivity_logrithmic`.  That helper implements the
+   :func:`thermal_diffusivity_logrithmic`.  That helper implements the
    log–ratio solution of the 1-D heat‐conduction equation for a sinusoidal
    boundary condition (Horton et al., 1934; de Vries, 1963):
 
@@ -900,7 +951,7 @@ Module Contents
    equation for a homogeneous medium subject to sinusoidal forcing
    (Carslaw & Jaeger, 1959).
 
-   .. method:: \*\*1. Log-Amplitude (α\_log)**
+   .. method:: 1. Log-Amplitude (α\_log)
 
       Uses the decay of the harmonic amplitude with depth:
 
@@ -910,7 +961,7 @@ Module Contents
                                    {2\,P\;\ln\bigl(A_1 / A_2\bigr)}
 
 
-   .. method:: \*\*2. Amplitude Ratio (α\_amp)**
+   .. method:: 2. Amplitude Ratio (α\_amp)
 
       Algebraically identical to the log-amplitude method but expressed
       directly in terms of the two amplitudes:
@@ -923,7 +974,7 @@ Module Contents
       where ``ω = 2π / P`` is the angular frequency.
 
 
-   .. method:: \*\*3. Phase Lag (α\_lag)**
+   .. method:: 3. Phase Lag (α\_lag)
 
       Relates the travel time (phase shift) of the temperature wave:
 
@@ -1008,12 +1059,12 @@ Module Contents
    *(z₁, z₂)* it
 
    1. Derives thermal diffusivity ``α`` with
-      :pyfunc:`calculate_thermal_diffusivity_for_pair`.
+      :func:`calculate_thermal_diffusivity_for_pair`.
    2. Converts ``α`` to thermal conductivity ``k`` via
-      :pyfunc:`thermal_conductivity`, using the mean volumetric water-
+      :func:`thermal_conductivity`, using the mean volumetric water-
       content of the two layers.
    3. Estimates instantaneous soil heat flux ``G`` by calling
-      :pyfunc:`soil_heat_flux`.
+      :func:`soil_heat_flux`.
 
    Results are returned in a *tidy*, hierarchical ``DataFrame`` whose
    outermost index encodes the depth pair (e.g. ``'0.05-0.10'``).
@@ -1039,7 +1090,7 @@ Module Contents
              inner index matches the *datetime* index of ``df`` (after
              dropping rows with *any* missing data).  For each analysis
              “method” returned by
-             :pyfunc:`calculate_thermal_diffusivity_for_pair` (keys of its
+             :func:`calculate_thermal_diffusivity_for_pair` (keys of its
              result dict) the following columns are present:
 
              ========  ==============================================================
@@ -1057,7 +1108,7 @@ Module Contents
      consistent sample support for derived quantities.
    * **Extensibility** – Additional diffusivity algorithms can be
      integrated by returning extra key–value pairs from
-     :pyfunc:`calculate_thermal_diffusivity_for_pair`; they will be
+     :func:`calculate_thermal_diffusivity_for_pair`; they will be
      propagated automatically.
    * **Performance** – The loop scales *O(n²)* with the number of
      depths.  For large sensor arrays, filter the pairs of interest
@@ -1151,3 +1202,22 @@ Module Contents
    :value: None
 
 
+.. py:function:: calculate_soil_heat_storage(df, depths, porosity=0.45, bulk_density=1.3)
+
+   Calculate soil heat storage and heat flux.
+
+   Parameters:
+   -----------
+   df : DataFrame
+       Must contain columns: 'T_5cm', 'T_10cm', etc. and 'SM_5cm', 'SM_10cm', etc.
+       where SM is volumetric soil moisture (0-1 or 0-100%)
+   depths : list
+       Measurement depths in cm, e.g., [5, 10, 20, 30, 40, 50]
+   porosity : float
+       Soil porosity (0-1), default 0.45
+   bulk_density : float
+       Dry soil bulk density (g/cm³), default 1.3
+
+   Returns:
+   --------
+   DataFrame with heat storage and flux values

--- a/docs/autoapi/soil_heat/storage_calculations/index.rst
+++ b/docs/autoapi/soil_heat/storage_calculations/index.rst
@@ -1,0 +1,99 @@
+soil_heat.storage_calculations
+==============================
+
+.. py:module:: soil_heat.storage_calculations
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   soil_heat.storage_calculations.compute_soil_storage_integrated
+   soil_heat.storage_calculations.compute_canopy_storage
+
+
+Module Contents
+---------------
+
+.. py:function:: compute_soil_storage_integrated(df: pandas.DataFrame, col_T5: str = 'T5cm', col_VWC5: str = 'VWC5cm', col_IRT: str = None, depth: float = 0.05, bulk_density: float = 1300.0, specific_heat_dry: float = 870.0, specific_heat_water: float = 4218.0) -> pandas.Series
+
+   Calculate the soil heat storage flux (S) in W/m² using a change-in-storage
+   approach.
+
+   This function estimates the energy stored or released in the upper soil
+   layer by accounting for the heat capacity of both the dry soil minerals and
+   the stored liquid water. It supports an integrated temperature approach if
+   infrared surface temperature (IRT) is available. In the slab approach, you
+   assume the estimate at the given depth applies to the whole slab above the
+   depth, whereas the IRT approach takes the mean between surface temperature
+   and temperature at depth.
+
+   Note that this method is the same as the method use to calculate soil heat
+   storage flux in the Campbell Scientific programs, though that progrmam uses
+   higher-frequency data for the calculations.
+
+   :param df: Input dataframe with a DatetimeIndex.
+   :type df: pd.DataFrame
+   :param col_T5: Column name for soil temperature at 5cm depth [°C].
+   :type col_T5: str, default "T5cm"
+   :param col_VWC5: Column name for Volumetric Water Content at 5cm depth [m³/m³].
+   :type col_VWC5: str, default "VWC5cm"
+   :param col_IRT: Column name for surface infrared temperature [°C]. If provided,
+                   the layer temperature is the average of surface and 5cm temps. Note
+                   that this must be surface temperature, not canopy temperature
+   :type col_IRT: str, optional
+   :param depth: The thickness of the soil layer being measured [m].
+   :type depth: float, default 0.05
+   :param bulk_density: Dry bulk density of the soil [kg/m³].
+   :type bulk_density: float, default 1300.0
+   :param specific_heat_dry: Specific heat capacity of dry soil minerals [J/(kg·K)].
+   :type specific_heat_dry: float, default 870.0
+   :param specific_heat_water: Specific heat capacity of water [J/(kg·K)].
+   :type specific_heat_water: float, default 4218.0
+
+   :returns: The calculated soil heat storage flux [W/m²].
+             Positive values indicate energy moving into storage (warming).
+   :rtype: pd.Series
+
+   .. rubric:: Notes
+
+   The canopy storage flux is calculated as:
+   $$S_{canopy} = \frac{m_{veg} \cdot C_{p} \cdot \Delta T}{\Delta t}$$
+
+   Where:
+   - $m_{veg}$ = Fresh biomass ($kg/m^2$), calculated as $(height / 100) \cdot density\_factor$
+   - $C_{p}$ = Specific heat of fresh vegetation ($\approx 3900 \text{ J/kg}\cdot\text{K}$)
+   - $\Delta T$ = Change in canopy temperature between time steps
+   - $\Delta t$ = Time step in seconds
+
+
+.. py:function:: compute_canopy_storage(df: pandas.DataFrame, col_irt: str = 'T_CANOPY', crop_type: str = 'alfalfa', height_cm: str | float = None, density_factor: float = None) -> pandas.Series
+
+   Calculate the energy storage flux of a plant canopy (S_canopy) in W/m².
+
+   This function estimates heat storage within biomass. It can handle dynamic
+   vegetation growth if a height column is provided, otherwise it falls back
+   to static heights. Height and density values can be entered by the user or
+   taken from a dictionary within the function.
+
+   Care should be taken to examine the crop default values and the specific
+   heat of the vegetation.
+
+   :param df: Input dataframe with a DatetimeIndex.
+   :type df: pd.DataFrame
+   :param col_irt: Column name for the canopy surface temperature [°C].
+   :type col_irt: str, default "T_CANOPY"
+   :param crop_type: Options: 'alfalfa', 'corn', 'hay', 'wetland'. Used to determine
+                     defaults for height and density.
+   :type crop_type: str, default "alfalfa"
+   :param height_cm: If str: The column name in `df` containing canopy height [cm] over time.
+                     If float: A static height value [cm].
+                     If None: Uses default height for the specified `crop_type`.
+   :type height_cm: str or float, optional
+   :param density_factor: Biomass density [kg/m² per meter height]. If None, uses default
+                          for the specified `crop_type`.
+   :type density_factor: float, optional
+
+   :returns: Energy storage flux [W/m²].
+   :rtype: pd.Series

--- a/docs/autoapi/soil_heat/wang_and_bouzeid/index.rst
+++ b/docs/autoapi/soil_heat/wang_and_bouzeid/index.rst
@@ -232,7 +232,7 @@ Module Contents
      returns 0.0.
    * **Vectorisation** – For vector or array input use
      :func:`numpy.vectorize` or wrap the function in
-     :pyfunc:`numpy.frompyfunc`; the core implementation is scalar for
+     :func:`numpy.frompyfunc`; the core implementation is scalar for
      numerical clarity.
    * **Usage** – ``g_z(t)`` can be convolved with an arbitrary surface
      heat-flux time series ``q₀(t)`` to obtain temperature at depth
@@ -393,7 +393,7 @@ Module Contents
        A : float
            Amplitude of the sinusoidal **surface heat flux** (W m⁻², positive
            downward).  Consistent with
-           :pyfunc:`sinusoidal_boundary_flux`.
+           :func:`sinusoidal_boundary_flux`.
        omega : float
            Angular frequency of the forcing (rad s⁻¹).
            For a diurnal wave ``omega = 2 * π / 86_400``.
@@ -530,7 +530,7 @@ Module Contents
          ``len(t) × 2000``.
        * **Coupling with temperature** –
          The companion function
-         :pyfunc:`soil_temperature_sinusoidal` gives *T(z,t)* under the
+         :func:`soil_temperature_sinusoidal` gives *T(z,t)* under the
          same boundary forcing; *G* and *T* satisfy Fourier’s law
          ``G = -k ∂T/∂z`` once thermal conductivity *k* is specified.
 

--- a/docs/autoapi/soil_heat/wang_and_yang/index.rst
+++ b/docs/autoapi/soil_heat/wang_and_yang/index.rst
@@ -51,103 +51,251 @@ Module Contents
 
    Compute heat flux *G* at cell interfaces using Fourier’s law.
 
-   :param Tz: Temperature at layer **centres** (K).
+   This function calculates the conductive heat flux between soil layers
+   based on the temperature gradient and thermal conductivity.
+
+   .. math:: G = -\lambda_s \frac{\partial T}{\partial z}
+
+   :param Tz: A 1D array of temperatures at the **centre** of each soil layer (K).
    :type Tz: ArrayLike
-   :param dz: Thickness of each layer (m).
+   :param dz: A 1D array of the thickness of each soil layer (m).
    :type dz: ArrayLike
-   :param lambda_s: Thermal conductivity for each layer (W m‑1 K‑1).
+   :param lambda_s: Thermal conductivity for each layer (W m⁻¹ K⁻¹). Can be a single
+                    value (for homogeneous soil) or an array matching `Tz`.
    :type lambda_s: ArrayLike or float
 
-   :returns: Heat flux at *interfaces* (positive downward) with shape ``len(Tz)+1``.
-   :rtype: np.ndarray
+   :returns: An array of heat fluxes (W m⁻²) at the *interfaces* between layers,
+             including the surface and bottom boundaries. The length of the
+             output is `len(Tz) + 1`. Positive values indicate downward flux.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: integrated_soil_heat_flux(rho_c: ArrayLike, T_before: ArrayLike, T_after: ArrayLike, dz: ArrayLike, dt: float, G_ref: float = 0.0) -> numpy.ndarray
 
-   Discrete integration of Eq. (3)/(5) to obtain heat‑flux profile.
+   Calculate the soil heat flux profile by integrating the change in
+   heat storage upwards from a reference depth (Yang & Wang 2008, Eq. 5).
 
-   :param rho_c: Volumetric heat capacity ``ρ_s c_s`` for each layer (J m‑3 K‑1).
+   .. math::
+       G(z_i) = G(z_{ref}) + \int_{z_i}^{z_{ref}} \rho_s c_s
+                \frac{\partial T}{\partial t} dz
+
+   :param rho_c: A 1D array of volumetric heat capacity (`ρ_s c_s`) for each soil
+                 layer (J m⁻³ K⁻¹).
    :type rho_c: ArrayLike
-   :param T_before: Temperatures at two successive timesteps (K).
+   :param T_before: A 1D array of temperatures at the start of the time step (K).
    :type T_before: ArrayLike
-   :param T_after: Temperatures at two successive timesteps (K).
+   :param T_after: A 1D array of temperatures at the end of the time step (K).
    :type T_after: ArrayLike
-   :param dz: Layer thicknesses (m).
+   :param dz: A 1D array of layer thicknesses (m).
    :type dz: ArrayLike
-   :param dt: Timestep (s).
+   :param dt: The duration of the time step (s).
    :type dt: float
-   :param G_ref: Heat flux at the lower reference depth *z_ref* (W m‑2).  Often ≈ 0.
-   :type G_ref: float, default 0
+   :param G_ref: The heat flux at the lower reference depth `z_ref` (W m⁻²). This
+                 is typically assumed to be zero at a sufficient depth, by default 0.0.
+   :type G_ref: float, optional
 
-   :returns: Heat flux at the *upper* interface of every layer, size ``len(dz)``.
-   :rtype: np.ndarray
+   :returns: An array of heat fluxes (W m⁻²) at the *upper interface* of each
+             layer, with a size of `len(dz)`.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: volumetric_heat_capacity(theta: ArrayLike, theta_sat: float | ArrayLike) -> numpy.ndarray
 
-   Volumetric heat capacity of moist soil.
+   Calculate the volumetric heat capacity of moist soil based on its
+   water content (Yang & Wang 2008, Eq. 4).
 
-   :param theta: Volumetric water content (m³ m‑3).
+   .. math::
+       \rho_s c_s = (1 - \theta_{sat}) \rho_{d}c_{d} + \theta \rho_w c_w
+
+   :param theta: Volumetric water content (m³ m⁻³).
    :type theta: ArrayLike
-   :param theta_sat: Soil porosity.
+   :param theta_sat: Soil porosity, i.e., saturated volumetric water content (m³ m⁻³).
    :type theta_sat: float or ArrayLike
 
-   :returns: ``ρ_s c_s`` (J m‑3 K‑1).
-   :rtype: np.ndarray
+   :returns: The volumetric heat capacity `ρ_s c_s` (J m⁻³ K⁻¹).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: stretched_grid(n: int, D: float, xi: float) -> numpy.ndarray
 
-   Generate *n* layer thicknesses following the exponential stretching rule.
+   Generate layer thicknesses for a vertically stretched grid.
 
-   :param n: Number of layers.
+   The grid layer thickness increases exponentially with depth, allowing
+   for higher resolution near the surface.
+
+   .. math:: \Delta z_i = \Delta z_0 \exp(\xi (i-1))
+
+   :param n: The number of soil layers.
    :type n: int
-   :param D: Total domain depth (m).
+   :param D: The total depth of the soil domain (m).
    :type D: float
-   :param xi: Stretching parameter; 0 → uniform grid.
+   :param xi: The stretching parameter. `xi = 0` results in a uniform grid.
+              `xi > 0` results in a grid that is finer at the top.
    :type xi: float
 
-   :returns: Thickness ``Δz_i`` for each layer *i* (m).
-   :rtype: np.ndarray
+   :returns: A 1D array of thickness `Δz_i` for each of the `n` layers (m).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: solve_tde(T_prev: ArrayLike, dz: ArrayLike, rho_c: ArrayLike, lambda_s: ArrayLike | float, Tsfc: float, Tbot: float, dt: float) -> numpy.ndarray
 
-   Implicit Crank‑Nicholson (θ = 1) solve of Eq. (7).
+   Solve the 1D thermal diffusion equation for one time step using an
+   implicit Crank-Nicolson scheme (Yang & Wang 2008, Eq. 7).
 
-   Boundary conditions (Eq. 7a, 7c) are Dirichlet.
+   This function sets up and solves the tridiagonal system of linear
+   equations `M * T_new = D` to find the temperature profile at the
+   next time step.
+
+   :param T_prev: Temperature profile at the previous time step (K).
+   :type T_prev: ArrayLike
+   :param dz: Layer thicknesses (m).
+   :type dz: ArrayLike
+   :param rho_c: Volumetric heat capacity of each layer (J m⁻³ K⁻¹).
+   :type rho_c: ArrayLike
+   :param lambda_s: Thermal conductivity of each layer (W m⁻¹ K⁻¹).
+   :type lambda_s: ArrayLike or float
+   :param Tsfc: Surface temperature boundary condition (K).
+   :type Tsfc: float
+   :param Tbot: Bottom temperature boundary condition (K).
+   :type Tbot: float
+   :param dt: Time step (s).
+   :type dt: float
+
+   :returns: The new temperature profile at `t + dt`, including boundary nodes.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: correct_profile(T_model: ArrayLike, depths_model: ArrayLike, T_obs: ArrayLike, depths_obs: ArrayLike) -> numpy.ndarray
 
-   Add linear‑interpolated bias (Eq. ΔT_k) to model profile.
+   Correct a modeled temperature profile using observed temperatures.
+
+   This function calculates the bias (error) between the model and
+   observations at the observation depths, then linearly interpolates
+   this bias across the entire model grid to correct the profile.
+
+   :param T_model: The modeled temperature profile (K).
+   :type T_model: ArrayLike
+   :param depths_model: The depths corresponding to `T_model` (m).
+   :type depths_model: ArrayLike
+   :param T_obs: The observed temperatures (K).
+   :type T_obs: ArrayLike
+   :param depths_obs: The depths of the observations (m).
+   :type depths_obs: ArrayLike
+
+   :returns: The corrected temperature profile.
+   :rtype: numpy.ndarray
 
 
 .. py:function:: surface_temperature_longwave(R_lw_up: float, R_lw_dn: float, emissivity: float = 0.98) -> float
 
-   Convert upward/downward long‑wave radiation to surface temperature (Eq. 8).
+   Calculate surface temperature from upward and downward long-wave
+   radiation measurements using the Stefan-Boltzmann law (Yang & Wang 2008, Eq. 8).
+
+   .. math::
+       T_s = \left[ \frac{R_{lw}^{\uparrow} - (1 - \epsilon) R_{lw}^{\downarrow}}
+                     {\epsilon \sigma} \right]^{1/4}
+
+   :param R_lw_up: Upwelling long-wave radiation (W m⁻²).
+   :type R_lw_up: float
+   :param R_lw_dn: Downwelling long-wave radiation (W m⁻²).
+   :type R_lw_dn: float
+   :param emissivity: Surface emissivity (dimensionless), by default 0.98.
+   :type emissivity: float, optional
+
+   :returns: The calculated surface temperature (K).
+   :rtype: float
 
 
 .. py:function:: thermal_conductivity_yang2008(theta: ArrayLike, theta_sat: float, rho_dry: float | ArrayLike) -> numpy.ndarray
 
-   Estimate soil thermal conductivity following Yang et al. (2005) (Eq. 9).
+   Estimate soil thermal conductivity based on soil moisture and dry
+   density, following Yang et al. (2005) as cited in
+   Yang & Wang (2008, Eq. 9).
+
+   :param theta: Volumetric water content (m³ m⁻³).
+   :type theta: ArrayLike
+   :param theta_sat: Saturated volumetric water content (porosity) (m³ m⁻³).
+   :type theta_sat: float
+   :param rho_dry: Dry soil bulk density (kg m⁻³).
+   :type rho_dry: float or ArrayLike
+
+   :returns: The estimated soil thermal conductivity `λ_s` (W m⁻¹ K⁻¹).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: flux_error_linear(rho_c: ArrayLike, S2_minus_S1: ArrayLike, dt: float) -> numpy.ndarray
 
-   Error introduced when using a LINEAR temperature profile (diagnostic).
+   Calculate the diagnostic error in heat flux that arises from assuming
+   a linear temperature profile between measurement points
+   (Yang & Wang 2008, Eq. 11).
+
+   .. math:: \Delta G_i = \frac{\rho_s c_s (S_{i,2} - S_{i,1})}{\Delta t}
+
+   :param rho_c: Volumetric heat capacity for each layer (J m⁻³ K⁻¹).
+   :type rho_c: ArrayLike
+   :param S2_minus_S1: The area difference representing the deviation from linearity.
+   :type S2_minus_S1: ArrayLike
+   :param dt: The time step (s).
+   :type dt: float
+
+   :returns: The flux error for each layer (W m⁻²).
+   :rtype: numpy.ndarray
 
 
 .. py:function:: surface_energy_residual(R_net: float, H: float, LE: float, G0: float) -> float
 
-   Return the residual *ΔE* in Eq. (12).
+   Calculate the residual of the surface energy budget (Yang & Wang 2008, Eq. 12).
+
+   .. math:: \Delta E = R_{net} - (H + LE + G_0)
+
+   :param R_net: Net radiation (W m⁻²).
+   :type R_net: float
+   :param H: Sensible heat flux (W m⁻²).
+   :type H: float
+   :param LE: Latent heat flux (W m⁻²).
+   :type LE: float
+   :param G0: Surface ground heat flux (W m⁻²).
+   :type G0: float
+
+   :returns: The energy balance residual `ΔE` (W m⁻²).
+   :rtype: float
 
 
 .. py:function:: tdec_step(T_prev: ArrayLike, dz: ArrayLike, theta: ArrayLike, theta_sat: float, rho_dry: float, lambda_const: float, Tsfc: float, Tbot: float, dt: float, depths_model: ArrayLike, T_obs: ArrayLike, depths_obs: ArrayLike) -> Tuple[numpy.ndarray, numpy.ndarray]
 
-   One integration step of the TDEC scheme.
+   Perform a single integration step of the TDEC (Temperature Diffusion
+   Error Correction) scheme.
 
-   :returns: * **T_corr** (*np.ndarray*) -- Corrected temperature profile at *t + dt*.
-             * **G_prof** (*np.ndarray*) -- Heat‑flux profile (W m‑2) at layer interfaces.
+   This function encapsulates the predict-correct sequence for one time step.
+
+   :param T_prev: Temperature profile from the previous time step (K).
+   :type T_prev: ArrayLike
+   :param dz: Layer thicknesses (m).
+   :type dz: ArrayLike
+   :param theta: Volumetric water content profile (m³ m⁻³).
+   :type theta: ArrayLike
+   :param theta_sat: Soil porosity (m³ m⁻³).
+   :type theta_sat: float
+   :param rho_dry: Dry soil bulk density (kg m⁻³).
+   :type rho_dry: float
+   :param lambda_const: A constant thermal conductivity for the prediction step (W m⁻¹ K⁻¹).
+   :type lambda_const: float
+   :param Tsfc: Surface temperature boundary condition (K).
+   :type Tsfc: float
+   :param Tbot: Bottom temperature boundary condition (K).
+   :type Tbot: float
+   :param dt: Time step (s).
+   :type dt: float
+   :param depths_model: Depths of the model grid nodes (m).
+   :type depths_model: ArrayLike
+   :param T_obs: Observed temperatures for the correction step (K).
+   :type T_obs: ArrayLike
+   :param depths_obs: Depths of the observed temperatures (m).
+   :type depths_obs: ArrayLike
+
+   :returns: A tuple containing:
+             - `T_corr`: The corrected temperature profile at `t + dt`.
+             - `G_prof`: The corresponding heat flux profile (W m⁻²) at layer interfaces.
+   :rtype: Tuple[np.ndarray, np.ndarray]
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,3 +5,89 @@ Usage
 To use Soil Heat in a project::
 
     import soil_heat
+
+FAO-56 Soil Heat Flux
+---------------------
+
+The `fao56_soil_heat_flux` module implements methods from the FAO-56 paper and the ASCE Standardized Reference ET equation.
+
+Daily Soil Heat Flux
+^^^^^^^^^^^^^^^^^^^^
+
+For daily time steps, soil heat flux is often assumed to be zero for a grass reference surface:
+
+.. code-block:: python
+
+    from soil_heat import soil_heat_flux_daily
+
+    g_daily = soil_heat_flux_daily()
+    print(f"Daily G: {g_daily} MJ m-2 day-1")
+
+Monthly Soil Heat Flux
+^^^^^^^^^^^^^^^^^^^^^^
+
+When both the previous and next month's mean air temperatures are available:
+
+.. code-block:: python
+
+    from soil_heat import soil_heat_flux_monthly
+
+    # Temps for March and May
+    t_mar, t_may = 14.1, 18.8
+    g_apr = soil_heat_flux_monthly(t_mar, t_may)
+    print(f"April G: {g_apr:.3f} MJ m-2 day-1")
+
+Hourly Soil Heat Flux
+^^^^^^^^^^^^^^^^^^^^^
+
+For hourly or sub-daily periods, G is estimated as a fraction of net radiation (Rn):
+
+.. code-block:: python
+
+    from soil_heat import soil_heat_flux_hourly
+
+    rn = 2.5  # MJ m-2 hr-1
+    g_hourly = soil_heat_flux_hourly(rn, is_daytime=True)
+    print(f"Hourly G: {g_hourly} MJ m-2 hr-1")
+
+Storage Calculations
+--------------------
+
+The `storage_calculations` module provides methods to estimate energy storage in the soil and canopy.
+
+Soil Heat Storage
+^^^^^^^^^^^^^^^^^
+
+Using the change-in-storage approach for a soil layer:
+
+.. code-block:: python
+
+    import pandas as pd
+    import numpy as np
+    from soil_heat import compute_soil_storage_integrated
+
+    # Create sample data
+    index = pd.date_range("2023-01-01", periods=2, freq="15T")
+    df = pd.DataFrame({
+        "T5cm": [10.0, 10.5],
+        "VWC5cm": [0.25, 0.26]
+    }, index=index)
+
+    # Compute storage flux (W/m2)
+    s_soil = compute_soil_storage_integrated(df, col_T5="T5cm", col_VWC5="VWC5cm")
+    print(s_soil)
+
+Canopy Heat Storage
+^^^^^^^^^^^^^^^^^^^
+
+Estimating heat storage within biomass:
+
+.. code-block:: python
+
+    from soil_heat import compute_canopy_storage
+
+    # Sample data with canopy temperature
+    df["T_CANOPY"] = [15.0, 16.0]
+
+    s_canopy = compute_canopy_storage(df, col_irt="T_CANOPY", crop_type="alfalfa")
+    print(s_canopy)

--- a/src/soil_heat/__init__.py
+++ b/src/soil_heat/__init__.py
@@ -17,6 +17,8 @@ Available submodules:
 - `liebethal_and_folken`: Functions from Liebethal & Foken (2006).
 - `wang_and_bouzeid`: Functions from Wang & Bou-Zeid (2012).
 - `wang_and_yang`: Functions from Yang & Wang (2008).
+- `fao56_soil_heat_flux`: FAO-56 and ASCE soil heat flux methods.
+- `storage_calculations`: Soil and canopy heat storage calculations.
 
 All functions are designed to work with NumPy arrays for efficient,
 vectorized computations.
@@ -32,3 +34,5 @@ from .gao_et_al import *
 from .liebethal_and_folken import *
 from .wang_and_bouzeid import *
 from .wang_and_yang import *
+from .fao56_soil_heat_flux import *
+from .storage_calculations import *

--- a/src/soil_heat/gao_et_al.py
+++ b/src/soil_heat/gao_et_al.py
@@ -601,7 +601,7 @@ def force_restore_gz(
     * :math:`\\partial T_g / \\partial t` … ground-temperature tendency
       (K s⁻¹)
     * :math:`\\lambda_s(C_v)` … soil thermal conductivity derived from
-      *C_v* via :pyfunc:`lambda_s_from_cv` (W m⁻¹ K⁻¹)
+      *C_v* via :func:`lambda_s_from_cv` (W m⁻¹ K⁻¹)
     * :math:`\\omega` … angular frequency of the diurnal cycle
       (rad s⁻¹)
     * :math:`T_g` / :math:`\\bar{T}_g` … instantaneous and running-mean
@@ -643,7 +643,7 @@ def force_restore_gz(
     Notes
     -----
     * **λ_s(C_v) mapping** – The function relies on a helper
-      :pyfunc:`lambda_s_from_cv` that converts volumetric heat capacity
+      :func:`lambda_s_from_cv` that converts volumetric heat capacity
       to thermal conductivity.  Ensure that this helper is present in
       the import path.
     * **Units** – Keep units internally consistent (SI).
@@ -1595,7 +1595,7 @@ def wbz12_g_gz(
     * A very small term ``+ 1e-12`` is added under the square root to
       avoid division by zero at *t = t₀*.
     * The complementary error function is evaluated with
-      :pyfunc:`numpy.erfc`, which is vectorized and avoids the SciPy
+      :func:`numpy.erfc`, which is vectorized and avoids the SciPy
       dependency.
 
     References

--- a/src/soil_heat/soil_heat.py
+++ b/src/soil_heat/soil_heat.py
@@ -410,7 +410,7 @@ def thermal_conductivity(
     * *α* – thermal diffusivity (m² s⁻¹),
     * *C_v(θ_v)* – volumetric heat capacity (J m⁻³ K⁻¹) as a function of
       volumetric water content *θ_v* (m³ m⁻³).
-      It is obtained from :pyfunc:`volumetric_heat_capacity`.
+      It is obtained from :func:`volumetric_heat_capacity`.
 
     Parameters
     ----------
@@ -431,7 +431,7 @@ def thermal_conductivity(
     Notes
     -----
     * **Volumetric heat capacity model** –
-      :pyfunc:`volumetric_heat_capacity` typically assumes a two‐phase
+      :func:`volumetric_heat_capacity` typically assumes a two‐phase
       mixture of mineral soil and water:
 
       .. math::
@@ -1009,7 +1009,7 @@ def calc_thermal_diffusivity_log_pair(df, depth1_col, depth2_col, z1, z2, period
     The function extracts the **first four consecutive samples** from two
     temperature records—one at the shallow depth ``z1`` and one at the deeper
     depth ``z2``—and passes them to
-    :pyfunc:`thermal_diffusivity_logrithmic`.  That helper implements the
+    :func:`thermal_diffusivity_logrithmic`.  That helper implements the
     log–ratio solution of the 1-D heat‐conduction equation for a sinusoidal
     boundary condition (Horton et al., 1934; de Vries, 1963):
 
@@ -1251,12 +1251,12 @@ def calculate_thermal_properties_for_all_pairs(
     *(z₁, z₂)* it
 
     1. Derives thermal diffusivity ``α`` with
-       :pyfunc:`calculate_thermal_diffusivity_for_pair`.
+       :func:`calculate_thermal_diffusivity_for_pair`.
     2. Converts ``α`` to thermal conductivity ``k`` via
-       :pyfunc:`thermal_conductivity`, using the mean volumetric water-
+       :func:`thermal_conductivity`, using the mean volumetric water-
        content of the two layers.
     3. Estimates instantaneous soil heat flux ``G`` by calling
-       :pyfunc:`soil_heat_flux`.
+       :func:`soil_heat_flux`.
 
     Results are returned in a *tidy*, hierarchical ``DataFrame`` whose
     outermost index encodes the depth pair (e.g. ``'0.05-0.10'``).
@@ -1289,7 +1289,7 @@ def calculate_thermal_properties_for_all_pairs(
         inner index matches the *datetime* index of ``df`` (after
         dropping rows with *any* missing data).  For each analysis
         “method” returned by
-        :pyfunc:`calculate_thermal_diffusivity_for_pair` (keys of its
+        :func:`calculate_thermal_diffusivity_for_pair` (keys of its
         result dict) the following columns are present:
 
         ========  ==============================================================
@@ -1306,7 +1306,7 @@ def calculate_thermal_properties_for_all_pairs(
       consistent sample support for derived quantities.
     * **Extensibility** – Additional diffusivity algorithms can be
       integrated by returning extra key–value pairs from
-      :pyfunc:`calculate_thermal_diffusivity_for_pair`; they will be
+      :func:`calculate_thermal_diffusivity_for_pair`; they will be
       propagated automatically.
     * **Performance** – The loop scales *O(n²)* with the number of
       depths.  For large sensor arrays, filter the pairs of interest

--- a/src/soil_heat/wang_and_bouzeid.py
+++ b/src/soil_heat/wang_and_bouzeid.py
@@ -281,7 +281,7 @@ def green_function_temperature(
       returns 0.0.
     * **Vectorisation** – For vector or array input use
       :func:`numpy.vectorize` or wrap the function in
-      :pyfunc:`numpy.frompyfunc`; the core implementation is scalar for
+      :func:`numpy.frompyfunc`; the core implementation is scalar for
       numerical clarity.
     * **Usage** – ``g_z(t)`` can be convolved with an arbitrary surface
       heat-flux time series ``q₀(t)`` to obtain temperature at depth
@@ -529,7 +529,7 @@ def soil_temperature_sinusoidal(
     A : float
         Amplitude of the sinusoidal **surface heat flux** (W m⁻², positive
         downward).  Consistent with
-        :pyfunc:`sinusoidal_boundary_flux`.
+        :func:`sinusoidal_boundary_flux`.
     omega : float
         Angular frequency of the forcing (rad s⁻¹).
         For a diurnal wave ``omega = 2 * π / 86_400``.
@@ -699,7 +699,7 @@ def soil_heat_flux_sinusoidal(
       ``len(t) × 2000``.
     * **Coupling with temperature** –
       The companion function
-      :pyfunc:`soil_temperature_sinusoidal` gives *T(z,t)* under the
+      :func:`soil_temperature_sinusoidal` gives *T(z,t)* under the
       same boundary forcing; *G* and *T* satisfy Fourier’s law
       ``G = -k ∂T/∂z`` once thermal conductivity *k* is specified.
 

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+import pytest
+from soil_heat import (
+    soil_heat_flux_general,
+    soil_heat_flux_monthly,
+    soil_heat_flux_hourly,
+    compute_soil_storage_integrated,
+    compute_canopy_storage
+)
+
+def test_fao56_general():
+    # FAO-56 Example 13 — March to April
+    g = soil_heat_flux_general(16.1, 14.1, delta_t=30.0, delta_z=1.0)
+    assert np.isclose(g, 0.14)
+
+def test_fao56_monthly():
+    # FAO-56 Example 13 — April soil heat flux (March = 14.1, May = 18.8)
+    g = soil_heat_flux_monthly(14.1, 18.8)
+    assert np.isclose(g, 0.329)
+
+def test_fao56_hourly():
+    # Daytime hour with Rn = 2.5 MJ m-2 hr-1
+    g = soil_heat_flux_hourly(2.5, is_daytime=True)
+    assert np.isclose(g, 0.25)
+
+def test_compute_soil_storage_integrated():
+    index = pd.date_range("2023-01-01", periods=2, freq="15min")
+    df = pd.DataFrame({
+        "T5cm": [10.0, 10.5],
+        "VWC5cm": [0.25, 0.25]
+    }, index=index)
+    s_soil = compute_soil_storage_integrated(df, col_T5="T5cm", col_VWC5="VWC5cm")
+    assert isinstance(s_soil, pd.Series)
+    assert not s_soil.isna().all()
+
+def test_compute_canopy_storage():
+    index = pd.date_range("2023-01-01", periods=2, freq="15min")
+    df = pd.DataFrame({
+        "T_CANOPY": [15.0, 16.0]
+    }, index=index)
+    s_canopy = compute_canopy_storage(df, col_irt="T_CANOPY", crop_type="alfalfa")
+    assert isinstance(s_canopy, pd.Series)
+    assert s_canopy.iloc[1] > 0


### PR DESCRIPTION
This PR improves the documentation of the `soil_heat` library by adding details and usage examples for the newly added `fao56_soil_heat_flux` and `storage_calculations` modules. It also updates the package's top-level `__init__.py` to export these modules, fixes documentation cross-reference directives, and adds unit tests to ensure the new components work as expected.

---
*PR created automatically by Jules for task [17697459835794973118](https://jules.google.com/task/17697459835794973118) started by @inkenbrandt*